### PR TITLE
Instructions for installing the certificate for Firefox

### DIFF
--- a/src/app/learn/get-started/prereqs/ssl-certificate/index.html
+++ b/src/app/learn/get-started/prereqs/ssl-certificate/index.html
@@ -52,6 +52,21 @@
         <li><p>After you return to the Certificate screen, click <strong>OK</strong>.</p></li>
     </ol>
 
+    <stache-page-anchor>
+        Installation for Firefox
+    </stache-page-anchor>
+    <ol>
+        <li><p>Download the <a href="https://raw.githubusercontent.com/blackbaud/skyux-builder/master/ssl/skyux-ca.crt">skyux-ca.crt</a>.</p></li>
+        <li><p>Type or copy <strong>about:preferences#privacy</strong> into the Firefox address bar.</p></li>
+        <li><p>Click <strong>View Certificates</strong> (near the bottom).</p></li>
+        <li><p>Click <strong>Authorities</strong>.</p></li>
+        <li><p>Click <strong>Import</strong>.</p></li>
+        <li><p>Open the previously downloaded <strong>skyux-ca.crt</strong>.</p></li>
+        <li><p>Check <strong>Trust this CA to identify websites</strong>.</p></li>
+        <li><p>Click <strong>OK</strong> on the options dialog.</p></li>
+        <li><p>Click <strong>OK</strong> on the certificates dialog.</p></li>
+    </ol>
+
     <stache-row>
         <stache-column screenSmall="6">
         </stache-column>


### PR DESCRIPTION
I tested these instructions on `FF 58.0b14` on macos.