### PR TITLE
Using info instead of warning

### DIFF
--- a/src/app/home.component.html
+++ b/src/app/home.component.html
@@ -21,7 +21,7 @@
       </p>
     </stache-page-summary>
 
-    <sky-alert alertType="warning" [closeable]="false">
+    <sky-alert alertType="info" [closeable]="false">
       This site details SKY UX support for the <a href="https://angular.io">latest version of Angular</a>. Visit our <strong><a href="https://skyux.developer.blackbaud.com">SKY UX 1 documentation</a></strong> for information related to <a href="https://angularjs.org">AngularJS (1.x)</a>.
     </sky-alert>
 


### PR DESCRIPTION
Incorporating feedback from @Blackbaud-PaulCrowder to use `info` instead of `warning`.