### PR TITLE
Fix tile event name, plus other doc tweaks.

### DIFF
--- a/src/app/components/tile/index.html
+++ b/src/app/components/tile/index.html
@@ -26,7 +26,7 @@
     <sky-demo-page-property
       propertyName="isCollapsedChange"
     >
-    Event emitted when the tile changes collapsed state. Returns <stache-code>true</stache-code> if the tile is collapsed. Otherwise returns <stache-code>false</stache-code>.
+    Event emitted when the tile changes collapsed state. Returns <stache-code>true</stache-code> if the tile is collapsed. Otherwise, returns <stache-code>false</stache-code>.
     </sky-demo-page-property>
   </sky-demo-page-properties>
 

--- a/src/app/components/tile/index.html
+++ b/src/app/components/tile/index.html
@@ -3,7 +3,7 @@
 
   <sky-demo-page-summary>
     <p>
-      The <stache-code>sky-tile</stache-code> directive creates a collapsible container and is the bulding block for pages and forms in a SKY UX application. The <stache-code>sky-tile-section</stache-code> directive is used to create padded sections inside a <stache-code>sky-tile</stache-code> element. Additionally, the <stache-code>sky-tile-summary</stache-code> directive may be placed inside the <stache-code>sky-tile</stache-code> directive to add summary information to the tile. Any <stache-code>sky-tile</stache-code> components used within a <stache-code>sky-tile-dashboard</stache-code> must be included as entry components in the application module.
+      The <stache-code>sky-tile</stache-code> directive creates a collapsible container that is a building block for pages and forms in SKY UX applications. The <stache-code>sky-tile-section</stache-code> directive creates a padded section inside a <stache-code>sky-tile</stache-code> element. The <stache-code>sky-tile-summary</stache-code> directive displays summary information inside a <stache-code>sky-tile</stache-code> element. If you use a <stache-code>sky-tile</stache-code> directive within a <stache-code>sky-tile-dashboard</stache-code> directive, you must <a routerLink="/learn/get-started/advanced/add-entry-components">include it as an entry component</a> in the application module.
     </p>
   </sky-demo-page-summary>
 
@@ -21,12 +21,12 @@
     <sky-demo-page-property
       propertyName="settingsClick"
     >
-    Event emitted when the settings button on the tile is clicked. The settings button will only appear if this output is placed on the tile.
+    Event emitted when the settings button on the tile is clicked. The settings button only appears if this output is placed on the tile.
     </sky-demo-page-property>
     <sky-demo-page-property
-      propertyName="isCollapsedChanged"
+      propertyName="isCollapsedChange"
     >
-    Event emitted when the tile changes collapsed state. Will return <stache-code>true</stache-code> if collapsed, <stache-code>false</stache-code> otherwise.
+    Event emitted when the tile changes collapsed state. Returns <stache-code>true</stache-code> if the tile is collapsed. Otherwise returns <stache-code>false</stache-code>.
     </sky-demo-page-property>
   </sky-demo-page-properties>
 
@@ -42,7 +42,7 @@
     <sky-demo-page-property
       propertyName="configChange"
     >
-    This event emits a <stache-code>SkyTileDashboardConfig</stache-code> when the tile dashboard changes state. This can occur when tiles are collapsed/expanded or when tiles are rearranged via drag and drop.
+    This event emits a <stache-code>SkyTileDashboardConfig</stache-code> object when the tile dashboard changes state. This occurs when tiles are collapsed or expanded and when tiles are rearranged via drag and drop.
     </sky-demo-page-property>
   </sky-demo-page-properties>
 
@@ -59,20 +59,20 @@
         <stache-code>componentType</stache-code> — The class type for the tile component.
       </li>
       <li>
-        <stache-code>providers</stache-code> An array of data providers that can be passed to the tile.
+        <stache-code>providers</stache-code> — An array of data providers that can be passed to the tile.
       </li>
     </ul>
     </sky-demo-page-property>
       <sky-demo-page-property
         propertyName="layout"
       >
-      A <stache-code>SkyTileDashboardConfigLayout</stache-code> object that describes the layout of the tile dashboard. The <stache-code>SkyTileDashboardConfigLayout</stache-code> object contains a <stache-code>singleColumn</stache-code> property of type <stache-code>SkyTileDashboardConfigLayoutColumn</stache-code> and a <stache-code>multiColumn</stache-code> property that is an array of type <stache-code> SkyTileDashboardConfigLayoutColumn</stache-code>. The <stache-code>singleColumn</stache-code> layout displays on small screens, while the <stache-code>multiColumn</stache-code> layout displays on larger screens. The <stache-code>SkyTileDashboardConfigLayoutColumn</stache-code> object contains an array of <stache-code>SkyTileDashboardConfigLayoutTile</stache-code> objects that indicate the order of tiles and have the following properties:
+      A <stache-code>SkyTileDashboardConfigLayout</stache-code> object that describes the layout of the tile dashboard. The <stache-code>SkyTileDashboardConfigLayout</stache-code> object contains a <stache-code>singleColumn</stache-code> property of type <stache-code>SkyTileDashboardConfigLayoutColumn</stache-code> and a <stache-code>multiColumn</stache-code> property that is an array of type <stache-code> SkyTileDashboardConfigLayoutColumn</stache-code>. The <stache-code>singleColumn</stache-code> layout displays on small screens, while the <stache-code>multiColumn</stache-code> layout displays on larger screens. The <stache-code>SkyTileDashboardConfigLayoutColumn</stache-code> object contains an array of <stache-code>SkyTileDashboardConfigLayoutTile</stache-code> objects that indicates the order of tiles. It has the following properties:
       <ul>
         <li>
           <stache-code>id</stache-code> — The identifier for the tile in the dashboard.
         </li>
         <li>
-          <stache-code>isCollapsed</stache-code> — A boolean value to indicate whether the specific tile is in an expanded or collapsed state.
+          <stache-code>isCollapsed</stache-code> — A boolean value that indicates whether the tile is in an expanded or collapsed state.
         </li>
       </ul>
     </sky-demo-page-property>


### PR DESCRIPTION
Based on https://github.com/blackbaud/skyux2/blob/master/src/modules/tiles/tile/tile.component.ts and https://github.com/blackbaud/skyux2/blob/master/src/modules/tiles/tile/fixtures/tile.component.fixture.html, I assumed we just need to change `isCollapsedChanged` to `isCollapsedChange`. While making this change I also noticed a misspelling ("bulding" instead of "building") and decided to make a few quick style/grammar fixes as well.