### PR TITLE
Update link to sky-grid on the sky-list page

### DIFF
--- a/src/app/components/list/grid/index.html
+++ b/src/app/components/list/grid/index.html
@@ -3,7 +3,7 @@
 
   <sky-demo-page-summary>
     <p>
-      This list view grid component displays a grid for a SKY UX-themed list of data. Internally, the <stache-code>sky-list-view-grid</stache-code> uses <a routerLink="../overview">the <stache-code>sky-grid</stache-code> component</a>, which contains documentation for <stache-code>sky-grid-column</stache-code>.
+      This list view grid component displays a grid for a SKY UX-themed list of data. Internally, the <stache-code>sky-list-view-grid</stache-code> uses <a routerLink="../../grid">the <stache-code>sky-grid</stache-code> component</a>, which contains documentation for <stache-code>sky-grid-column</stache-code>.
     </p>
     <p>
       The list view grid component is designed for use within <a routerLink="../overview">a list component</a>.


### PR DESCRIPTION
The link for "the sky-grid component" was actually pointing to the documentation for the List overview and not for the sky-grid page.