### PR TITLE
Updated plunker service to specify versions of NG + RXJS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ jspm_packages
 
 # SKY UX temp directory
 .skyuxtmp
+.skypageslocales
 
 # SKY UX build directory
 dist

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   "author": "Blackbaud, Inc.",
   "license": "MIT",
   "dependencies": {
-    "@blackbaud/skyux": "2.12.0",
+    "@blackbaud/skyux": "2.12.2",
     "@blackbaud/skyux-design-tokens": "0.0.8",
-    "@blackbaud/stache": "2.4.0"
+    "@blackbaud/stache": "2.7.1"
   },
   "devDependencies": {
-    "@blackbaud/skyux-builder": "1.10.0"
+    "@blackbaud/skyux-builder": "1.15.0"
   },
   "repository": {
     "type": "git",

--- a/src/app/components/shared/demo-page-code.component.scss
+++ b/src/app/components/shared/demo-page-code.component.scss
@@ -23,29 +23,12 @@
   }
 }
 
-.sky-demo-page-code-header {
-  position: relative;
-}
-
 .sky-demo-page-code-plunker {
-  position: static;
-  text-align: right;
   margin-bottom: 15px;
 
   @media (min-width: 768px) {
-    position: absolute;
-    right: 0;
-    bottom: 12px;
-    margin-bottom: 0;
-  }
-}
-
-// This can be removed after the next Stache2 release:
-// https://github.com/blackbaud/stache2/pull/314
-/deep/
-.stache-table-of-contents {
-  .stache-nav-list {
-    list-style-type: decimal !important;
-    margin-left: 15px !important;
+    margin-top: -60px;
+    margin-bottom: 25px;
+    text-align: right;
   }
 }

--- a/src/app/components/shared/demo-page-plunker-service.ts
+++ b/src/app/components/shared/demo-page-plunker-service.ts
@@ -1,12 +1,23 @@
 /* tslint:disable max-line-length */
 
-import { Injectable } from '@angular/core';
+import { Injectable, VERSION } from '@angular/core';
+
+import { SkyAppConfig } from '@blackbaud/skyux-builder/runtime';
 
 import { SkyDemoPageCodeFile } from './demo-page-code-file';
 
 @Injectable()
 export class SkyDemoPagePlunkerService {
+
+  constructor(
+    private skyAppConfig: SkyAppConfig
+  ) { }
+
   public getFiles(codeFiles: SkyDemoPageCodeFile[]): any[] {
+    const skyuxDistPath = this.skyAppConfig.runtime.command === 'serve'
+      ? 'dev:dist/bundles/core.umd.js'
+      : 'npm:@blackbaud/skyux/dist/bundles/core.umd.js';
+
     let declarations: string[] = [];
     let bootstrapSelectors: string[] = [];
     let entryComponents: string[] = [];
@@ -45,8 +56,9 @@ export class SkyDemoPagePlunkerService {
       ...files,
       {
         name: 'config.js',
-        content:
-`System.config({
+        content: `
+var ngVersion = '@${VERSION.full}';
+System.config({
   //use typescript for compilation
   transpiler: 'typescript',
   //typescript compiler options
@@ -54,29 +66,30 @@ export class SkyDemoPagePlunkerService {
     emitDecoratorMetadata: true
   },
   paths: {
-    'npm:': 'https://unpkg.com/'
+    'npm:': 'https://unpkg.com/',
+    'dev:': 'https://localhost:5000/'
   },
   //map tells the System loader where to look for things
   map: {
 
     'app': '.',
 
-    '@angular/core': 'npm:@angular/core@4.2.5/bundles/core.umd.js',
-    '@angular/common': 'npm:@angular/common@4.2.5/bundles/common.umd.js',
-    '@angular/compiler': 'npm:@angular/compiler@4.2.5/bundles/compiler.umd.js',
-    '@angular/platform-browser': 'npm:@angular/platform-browser@4.2.5/bundles/platform-browser.umd.js',
-    '@angular/platform-browser-dynamic': 'npm:@angular/platform-browser-dynamic@4.2.5/bundles/platform-browser-dynamic.umd.js',
-    '@angular/http': 'npm:@angular/http@4.2.5/bundles/http.umd.js',
-    '@angular/router': 'npm:@angular/router@4.2.5/bundles/router.umd.js',
-    '@angular/forms': 'npm:@angular/forms@4.2.5/bundles/forms.umd.js',
-    '@angular/animations': 'npm:@angular/animations@4.2.5/bundles/animations.umd.js',
-    '@angular/platform-browser/animations': 'npm:@angular/platform-browser@4.2.5/bundles/platform-browser-animations.umd.js',
-    '@angular/animations/browser': 'npm:@angular/animations@4.2.5/bundles/animations-browser.umd.js',
+    '@angular/core': 'npm:@angular/core' + ngVersion + '/bundles/core.umd.js',
+    '@angular/common': 'npm:@angular/common' + ngVersion + '/bundles/common.umd.js',
+    '@angular/compiler': 'npm:@angular/compiler' + ngVersion + '/bundles/compiler.umd.js',
+    '@angular/platform-browser': 'npm:@angular/platform-browser' + ngVersion + '/bundles/platform-browser.umd.js',
+    '@angular/platform-browser-dynamic': 'npm:@angular/platform-browser-dynamic' + ngVersion + '/bundles/platform-browser-dynamic.umd.js',
+    '@angular/http': 'npm:@angular/http' + ngVersion + '/bundles/http.umd.js',
+    '@angular/router': 'npm:@angular/router' + ngVersion + '/bundles/router.umd.js',
+    '@angular/forms': 'npm:@angular/forms' + ngVersion + '/bundles/forms.umd.js',
+    '@angular/animations': 'npm:@angular/animations' + ngVersion + '/bundles/animations.umd.js',
+    '@angular/platform-browser/animations': 'npm:@angular/platform-browser' + ngVersion + '/bundles/platform-browser-animations.umd.js',
+    '@angular/animations/browser': 'npm:@angular/animations' + ngVersion + '/bundles/animations-browser.umd.js',
     'tslib': 'npm:tslib@1.6.1',
 
-    'rxjs': 'npm:rxjs',
+    'rxjs': 'npm:rxjs@5.4.3',
     'typescript': 'npm:typescript@2.2.1/lib/typescript.js',
-    '@blackbaud/skyux/dist/core': 'npm:@blackbaud/skyux/dist/bundles/core.umd.js',
+    '@blackbaud/skyux/dist/core': '${skyuxDistPath}',
 
     'moment': 'npm:moment/moment.js',
 
@@ -166,9 +179,7 @@ export class AppComponent() { }`
       },
       {
         name: 'main.ts',
-        content:
-`
-import { Component, NgModule } from '@angular/core';
+        content: `import { Component, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
 import { SkyModule } from '@blackbaud/skyux/dist/core';
@@ -177,6 +188,10 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 ${imports.join('\n')}
 
 import { AppComponent } from './app.component';
+
+// This is temporary to get list-view-grid functioning properly
+// A future relese of SKY UX components would fix this.
+import 'rxjs/add/operator/takeUntil';
 
 @NgModule({
   imports: [

--- a/src/app/components/shared/demo-page-plunker-service.ts
+++ b/src/app/components/shared/demo-page-plunker-service.ts
@@ -190,7 +190,7 @@ ${imports.join('\n')}
 import { AppComponent } from './app.component';
 
 // This is temporary to get list-view-grid functioning properly
-// A future relese of SKY UX components would fix this.
+// A future release of SKY UX components would fix this.
 import 'rxjs/add/operator/takeUntil';
 
 @NgModule({

--- a/src/app/components/shared/demo-page-plunker-service.ts
+++ b/src/app/components/shared/demo-page-plunker-service.ts
@@ -59,19 +59,37 @@ export class SkyDemoPagePlunkerService {
         content: `
 var ngVersion = '@${VERSION.full}';
 System.config({
-  //use typescript for compilation
+  // use typescript for compilation
   transpiler: 'typescript',
-  //typescript compiler options
+
+  // typescript compiler options
   typescriptOptions: {
     emitDecoratorMetadata: true
   },
+
   paths: {
     'npm:': 'https://unpkg.com/',
     'dev:': 'https://localhost:5000/'
   },
-  //map tells the System loader where to look for things
-  map: {
 
+  // See: https://embed.plnkr.co/4Y6KAJ28Wwua8RSVaV8A/
+  bundles: {
+    "npm:rxjs-system-bundle@5.4.3/Rx.system.js": [
+      "rxjs",
+      "rxjs/*",
+      "rxjs/operator/*",
+      "rxjs/operators/*",
+      "rxjs/observable/*",
+      "rxjs/scheduler/*",
+      "rxjs/symbol/*",
+      "rxjs/add/operator/*",
+      "rxjs/add/observable/*",
+      "rxjs/util/*"
+    ]
+  },
+
+  // map tells the System loader where to look for things
+  map: {
     'app': '.',
 
     '@angular/core': 'npm:@angular/core' + ngVersion + '/bundles/core.umd.js',
@@ -85,17 +103,13 @@ System.config({
     '@angular/animations': 'npm:@angular/animations' + ngVersion + '/bundles/animations.umd.js',
     '@angular/platform-browser/animations': 'npm:@angular/platform-browser' + ngVersion + '/bundles/platform-browser-animations.umd.js',
     '@angular/animations/browser': 'npm:@angular/animations' + ngVersion + '/bundles/animations-browser.umd.js',
-    'tslib': 'npm:tslib@1.6.1',
-
-    'rxjs': 'npm:rxjs@5.4.3',
-    'typescript': 'npm:typescript@2.2.1/lib/typescript.js',
     '@blackbaud/skyux/dist/core': '${skyuxDistPath}',
-
-    'moment': 'npm:moment/moment.js',
-
     'microedge-rxstate/dist': 'npm:microedge-rxstate/dist/index.js',
+    'moment': 'npm:moment/moment.js',
+    'tslib': 'npm:tslib@1.6.1',
+    'typescript': 'npm:typescript@2.2.1/lib/typescript.js',
 
-    //dragula packages
+    // dragula packages
     'ng2-dragula/ng2-dragula': 'npm:ng2-dragula',
     'dragula': 'npm:dragula',
     'contra': 'npm:contra',
@@ -104,14 +118,12 @@ System.config({
     'crossvent': 'npm:crossvent/src',
     'custom-event': 'npm:custom-event'
   },
-  //packages defines our app package
+
+  // packages defines our app package
   packages: {
     app: {
       main: './main.ts',
       defaultExtension: 'ts'
-    },
-    rxjs: {
-      defaultExtension: 'js'
     },
     '@blackbaud/skyux/dist/core': {
        format: 'cjs'
@@ -119,7 +131,9 @@ System.config({
     'ng2-dragula/ng2-dragula': {
       main: 'ng2-dragula.js',
       defaultExtension: 'js'
-
+    },
+    'rxjs': {
+      defaultExtension: false
     },
     'dragula': { main: 'dragula.js', defaultExtension: 'js' },
     'contra': { main: 'contra.js', defaultExtension: 'js' },
@@ -181,7 +195,7 @@ export class AppComponent() { }`
         name: 'main.ts',
         content: `import { Component, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { SkyModule } from '@blackbaud/skyux/dist/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
@@ -189,14 +203,11 @@ ${imports.join('\n')}
 
 import { AppComponent } from './app.component';
 
-// This is temporary to get list-view-grid functioning properly
-// A future release of SKY UX components would fix this.
-import 'rxjs/add/operator/takeUntil';
-
 @NgModule({
   imports: [
     BrowserModule,
     FormsModule,
+    ReactiveFormsModule,
     SkyModule
   ],
   declarations: [

--- a/src/app/learn/get-started/advanced/route-params/index.html
+++ b/src/app/learn/get-started/advanced/route-params/index.html
@@ -21,11 +21,11 @@
   <stache-code-block>
     You are viewing dog 42.
   </stache-code-block>
-  
+
   <p>
     To demonstrate how to use route parameters, let's modify the About page that the template includes in your SPA when you create an application. For this example, we'll create a service to mimic communication with a database, and then we'll create an <stache-code>_id</stache-code> subfolder for the route parameters.
   </p>
-  
+
   <ol>
     <li>
       <p>
@@ -58,9 +58,9 @@ export class AboutService {
       email: 'michael@jordon.net'
     }
   ];
-  
+
   public getUsers = () => this.users;
-  
+
   public getUserById = (id: string) => this.users.filter(user => user.id === id)[0];
 }
 </stache-code-block>
@@ -131,13 +131,13 @@ export class AboutUserComponent implements OnInit {
 
   @Input()
   public userId: string;
-  
+
   public user: any;
-  
+
   constructor(
     private aboutService: AboutService
   ) { }
-  
+
   public ngOnInit() {
     this.user = this.aboutService.getUserById(this.userId);
   }
@@ -166,7 +166,7 @@ export class AboutUserComponent implements OnInit {
       <stache-code-block>
 <app-nav></app-nav>
 
-<sky-alert alertType="info">The <code>id</code> parameter is automatically available and can be passed in to our <code>MyAboutUser</code> component.  Using id: {{ id }}.</sky-alert>
+<sky-alert alertType="info">The <stache-code>id</stache-code> parameter is automatically available and can be passed in to our <stache-code>MyAboutUser</stache-code> component.  Using id: {{ id }}.</sky-alert>
 
 <my-about-user [userId]="id"></my-about-user>
       </stache-code-block>

--- a/src/app/styles.scss
+++ b/src/app/styles.scss
@@ -8,53 +8,6 @@ p {
   line-height: 1.6em !important;
 }
 
-code {
-  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
-  font-size: 90%;
-  background-color: scale-color($color: $sky-highlight-color-danger, $lightness: 90%);
-  border-radius: 4px;
-  color: scale-color($color: $sky-color-red-50, $lightness: -20%);
-  padding: 2px 4px;
-}
-
-/* Prism overrides */
-/* All colors were chosen to meet accessibility contrast ratio requirements */
-.token {
-  &.atrule,
-  &.attr-value,
-  &.keyword {
-    color: scale-color($color: $sky-color-blue-50, $lightness: -20%);
-  }
-
-  &.selector,
-  &.attr-name,
-  &.string,
-  &.char,
-  &.builtin,
-  &.inserted {
-    color: scale-color($color: $sky-color-green-50, $lightness: -30%);
-  }
-
-  &.property,
-  &.tag,
-  &.boolean,
-  &.number,
-  &.constant,
-  &.symbol,
-  &.deleted {
-    color: scale-color($color: $sky-color-red-50, $lightness: -20%);
-  }
-
-  &.function {
-    color: scale-color($color: $sky-color-purple-50, $lightness: -20%);
-  }
-
-  &.punctuation,
-  &.operator {
-    color: scale-color($color: $sky-color-gray-70, $lightness: -20%);
-  }
-}
-
 .sky-demo-bg-gray {
   background-color: $sky-border-color-neutral-light !important;
   padding: 10px !important;
@@ -166,7 +119,7 @@ code {
   }
 }
 
-// Start content tables 
+// Start content tables
 .content-table {
   border-collapse: collapse;
   td, th {


### PR DESCRIPTION
This makes test https://github.com/blackbaud/skyux2/pull/1491 easier to test.  I should mention, I wasn't able to solve the `takeUntil` error on the `list-view-grid`.  Line 194 is an attempt to quickly solve that in the docs (for now).

To test:

- `npm install -g serve` (or similar package).  The latest version of `serve` inadvertently made node >= 7.6 a requirement.  For now, I would run `npm install -g serve@6.5.3`.  https://github.com/zeit/serve/issues/348
- In skyux repo
  - `npm run build`
  - `serve . --cors --ssl --cache 0` (or similar command)
  - Open `https://localhost:5000` and approve SSL cert
- In skyux2-docs repo
  - `skyux serve`

I did evaluate StackBlitz, and think that will be a logical move for us, but am waiting on https://github.com/stackblitz/core/issues/437 before investing too much more time.  I've saved my work at https://github.com/blackbaud/skyux2-docs/tree/stackblitz-service until then.