### PR TITLE
Remove stache-code for users who copy/paste

### DIFF
--- a/src/app/learn/get-started/advanced/route-params/index.html
+++ b/src/app/learn/get-started/advanced/route-params/index.html
@@ -166,7 +166,7 @@ export class AboutUserComponent implements OnInit {
       <stache-code-block>
 <app-nav></app-nav>
 
-<sky-alert alertType="info">The <stache-code>id</stache-code> parameter is automatically available and can be passed in to our <stache-code>MyAboutUser</stache-code> component.  Using id: {{ id }}.</sky-alert>
+<sky-alert alertType="info">The 'id' parameter is automatically available and can be passed in to our 'MyAboutUser' component.  Using id: {{ id }}.</sky-alert>
 
 <my-about-user [userId]="id"></my-about-user>
       </stache-code-block>


### PR DESCRIPTION
Certain folks using the docs may not have Stache2 installed in their demo SPAs, and so snippets containing components from it will throw unexpected errors. There's probably a better way to highlight those two words (id and MyAboutUser), but just wanted to call it out as something worth fixing due to this thread here: https://blackbaud.slack.com/archives/C3TQ4C0KG/p1527619236000336

