### PR TITLE
added tip for which v6 option to download

### DIFF
--- a/src/app/learn/get-started/prereqs/initial-setup/index.html
+++ b/src/app/learn/get-started/prereqs/initial-setup/index.html
@@ -20,6 +20,9 @@
     Do not use Node.js version 7 or higher.
   </sky-alert>
   <p>
+    For Windows users, download the <stache-code>msi</stache-code> version from the v6 list.
+  </p>
+  <p>
     For Mac OS X and Linux, we recommend that you use <a href="https://github.com/creationix/nvm">Node Version Manager (nvm)</a> to wrap your NodeJS installation so that it installs in your user directory and avoids permissions-related issues.
   </p>
 

--- a/src/app/learn/get-started/prereqs/initial-setup/index.html
+++ b/src/app/learn/get-started/prereqs/initial-setup/index.html
@@ -20,7 +20,7 @@
     Do not use Node.js version 7 or higher.
   </sky-alert>
   <p>
-    For Windows users, download the <stache-code>msi</stache-code> version from the v6 list.
+    For Windows, download the <stache-code>msi</stache-code> version from the v6 list.
   </p>
   <p>
     For Mac OS X and Linux, we recommend that you use <a href="https://github.com/creationix/nvm">Node Version Manager (nvm)</a> to wrap your NodeJS installation so that it installs in your user directory and avoids permissions-related issues.


### PR DESCRIPTION
Suggesting an edit for Windows users to specify which Node.js option to download from the v6 list.