### PR TITLE
Introducing travis_wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,6 @@ before_install:
   - sudo dpkg -i google-chrome*.deb
   - rm google-chrome*.deb
   - npm install -g @blackbaud/skyux-cli
+
+# Identical to package.json except for travis wait
+script: skyux lint && skyux test && skyux e2e && travis_wait skyux build


### PR DESCRIPTION
This increased the default timeout in Travis for the `skyux build` command from 10 minutes to 30 minutes.  I think this will help with out build timeouts.