### PR TITLE
added note about builder version reqs

### DIFF
--- a/src/app/learn/get-started/advanced/localization/index.html
+++ b/src/app/learn/get-started/advanced/localization/index.html
@@ -8,6 +8,10 @@
       SKY UX Builder provides the capability to declare localization strings <a routerLink="/learn/reference/naming-and-placement">in a JSON file </a> and then reference those strings throughout your SPA using the <stache-code>skyAppResources</stache-code> pipe or the <stache-code>SkyAppResourcesService</stache-code> service in <stache-code>@blackbaud/skyux-builder/runtime/i18n</stache-code>.
     </p>
   </stache-page-summary>
+    
+  <sky-alert alertType="info">
+    SKY UX Builder version <stache-code>1.14</stache-code> or later is required for a library to provide its own resource files. The consuming SPA must also be on version <stache-code>1.14</stache-code> or later.
+  </sky-alert>
 
   <stache-page-anchor>
     Declare and reference localization strings


### PR DESCRIPTION
I'm not sure if it reads too choppy as is, but I also wasn't sure if, "For a library to provide its own resource files, SKY UX Builder and the consuming SPA must be on version 1.14 or later," changed the meaning.