### PR TITLE
Adjust indent on new config docs

### DIFF
--- a/src/app/learn/reference/configuration/index.html
+++ b/src/app/learn/reference/configuration/index.html
@@ -282,23 +282,23 @@
           }
         }
         </stache-code-block>
-      </li>
-    </ul>
-    <p>
-      When using this format, in addition to the <stache-code>value</stache-code> property, you can also specify the <stache-code>required</stache-code> and <stache-code>excludeFromRequests</stache-code> parameters.
-    </p>
-    <ul>
-      <li>
         <p>
-          <stache-code>excludeFromRequest</stache-code> — By default, <stache-code>SkyAuthHttp</stache-code> and <stache-code>SkyAuthHttpClient</stache-code> include any parameter with listed values in their requests. This parameter applies when a consumer wants to track a parameter without including it in the http call.
+          When using this format, in addition to the <stache-code>value</stache-code> property, you can also specify the <stache-code>required</stache-code> and <stache-code>excludeFromRequests</stache-code> parameters.
         </p>
-      </li>
-      <li>
-        <p>
-          <stache-code>required</stache-code> — For the <stache-code>envid</stache-code>, <stache-code>leid</stache-code>, and <stache-code>svcid</stache-code> parameters, <stache-code>@blackbaud/skyux-builder</stache-code> and <stache-code>@skyux-sdk/builder</stache-code> pass the <stache-code>required</stache-code> state to the <stache-code>auth-client</stache-code>, which attempts to resolve the default value if one is available, show the welcome screen if multiple are available, or show an error if none are available.</p>
-        <p>
-          For custom required parameters, no logic is applied, and users can use the <stache-code>SkyuxConfigParams</stache-code> class to interact with them.
-        </p>
+        <ul>
+          <li>
+            <p>
+              <stache-code>excludeFromRequest</stache-code> — By default, <stache-code>SkyAuthHttp</stache-code> and <stache-code>SkyAuthHttpClient</stache-code> include any parameter with listed values in their requests. This parameter applies when a consumer wants to track a parameter without including it in the http call.
+            </p>
+          </li>
+          <li>
+            <p>
+              <stache-code>required</stache-code> — For the <stache-code>envid</stache-code>, <stache-code>leid</stache-code>, and <stache-code>svcid</stache-code> parameters, <stache-code>@blackbaud/skyux-builder</stache-code> and <stache-code>@skyux-sdk/builder</stache-code> pass the <stache-code>required</stache-code> state to the <stache-code>auth-client</stache-code>, which attempts to resolve the default value if one is available, show the welcome screen if multiple are available, or show an error if none are available.</p>
+            <p>
+              For custom required parameters, no logic is applied, and users can use the <stache-code>SkyuxConfigParams</stache-code> class to interact with them.
+            </p>
+          </li>
+        </ul>
       </li>
     </ul>
     <p>


### PR DESCRIPTION
Moving the new content within the `li` tag for the example that it is describing so that the indent coincides with what's being described.