### PR TITLE
Maintenance 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
   "author": "Blackbaud, Inc.",
   "license": "MIT",
   "dependencies": {
-    "@blackbaud/skyux": "2.46.0",
+    "@blackbaud/skyux": "2.46.1",
     "@blackbaud/skyux-design-tokens": "0.0.11",
-    "@blackbaud/stache": "2.15.3",
-    "@skyux/action-bars": "3.0.0"
+    "@blackbaud/stache": "2.16.0",
+    "@skyux/action-bars": "3.0.1"
   },
   "devDependencies": {
-    "@blackbaud/skyux-builder": "1.33.0"
+    "@blackbaud/skyux-builder": "1.33.1"
   },
   "repository": {
     "type": "git",

--- a/skyuxconfig.json
+++ b/skyuxconfig.json
@@ -17,7 +17,12 @@
       "footer": {
       },
       "searchConfig": {
-        "is_internal": false
+        "is_internal": false,
+        "site_names": [
+          "skyux",
+          "bb-help-docs",
+          "skyux-migration-guide"
+        ]
       }
     }
   },

--- a/src/app/components/form/index.html
+++ b/src/app/components/form/index.html
@@ -14,9 +14,9 @@
       <input type="text" class="sky-form-control" aria-label="basic-input-example" placeholder="Enter text" />
     </div>
 
-    <stache-code-block>
+    <sky-code-block>
       <input type="text" class="sky-form-control" aria-label="basic-input-example" placeholder="Enter text"/>
-    </stache-code-block>
+    </sky-code-block>
   </div>
 
    <div>
@@ -30,12 +30,12 @@
       <input class="sky-form-control" id="basic-input-with-label-example" type="text" placeholder="(201) 555-5555" />
     </div>
 
-    <stache-code-block>
+    <sky-code-block>
      <label for="basic-input-with-label-example" class="sky-control-label">
         Phone number
       </label>
       <input class="sky-form-control" id="basic-input-with-label-example" type="text" placeholder="(201) 555-5555" />
-    </stache-code-block>
+    </sky-code-block>
   </div>
 
   <div>
@@ -49,7 +49,7 @@
       <input class="sky-form-control" id="required-input-with-label-example" type="text" aria-required="true" required placeholder="Ex: Smith"/>
     </div>
 
-    <stache-code-block>
+    <sky-code-block>
       <label
         for="required-input-with-label-example"
         class="sky-control-label sky-control-label-required">
@@ -62,9 +62,9 @@
         placeholder="Ex: Smith"
         aria-required="true"
         required />
-    </stache-code-block>
+    </sky-code-block>
   </div>
-	
+
 	<div>
 	<stache-page-anchor>Error states</stache-page-anchor>
 	<p>If a form field that uses Angular validation is in an invalid state, the input is styled with a red glow. The <stache-code>ng-invalid</stache-code> and <stache-code>ng-touched</stache-code> control status CSS classes indicate when the input is in an invalid state. For more information, see <a href="https://angular.io/guide/form-validation">the Angular form validation docs</a>.</p>
@@ -77,7 +77,7 @@
 			<div class="sky-error-label">Enter a valid value.</div>
     </div>
 
-    <stache-code-block>
+    <sky-code-block>
       <label for="input-with-error-example" class="sky-control-label">
         Age
       </label>
@@ -87,9 +87,9 @@
 
       <div *ngIf="age.errors.invalid" class="sky-error-label">
         Enter a valid value.
-      </div> 
-    </stache-code-block>
-	
+      </div>
+    </sky-code-block>
+
 	</div>
 
   <div>
@@ -109,7 +109,7 @@
       <input class="sky-form-control" id="form-group-second-input-example" type="text" />
     </div>
 
-    <stache-code-block>
+    <sky-code-block>
       <div class="sky-form-group" style="max-width: 50%">
         <label for="form-group-first-input-example" class="sky-control-label">
           First name
@@ -122,7 +122,7 @@
         </label>
         <input class="sky-form-control" id="form-group-second-input-example" type="text" />
       </div>
-    </stache-code-block>
+    </sky-code-block>
   </div>
 
 </stache>

--- a/src/app/components/shared/demo-page-code.component.html
+++ b/src/app/components/shared/demo-page-code.component.html
@@ -23,10 +23,10 @@
     <sky-tab
       *ngFor="let codeFile of codeFilesForBinding"
       [tabHeading]="codeFile.name">
-      <stache-code-block
+      <sky-code-block
         [code]="codeFile.codeImports"
         [languageType]="codeFile.language">
-      </stache-code-block>
+      </sky-code-block>
     </sky-tab>
   </sky-tabset>
 </section>

--- a/src/app/components/shared/demo-page.component.html
+++ b/src/app/components/shared/demo-page.component.html
@@ -1,5 +1,6 @@
 <stache
   layout="container"
+  showTableOfContents="true"
   [pageTitle]="pageTitle">
 
   <stache-page-summary>
@@ -18,15 +19,11 @@
     <ng-content select="sky-demo-page-summary"></ng-content>
   </stache-page-summary>
 
-  <stache-table-of-contents
-    [routes]="tableOfContentsRoutes">
-  </stache-table-of-contents>
-
   <ng-container *ngIf="npmInstall">
     <stache-page-anchor>
       Installation
     </stache-page-anchor>
-    <stache-code-block [code]="npmInstall"></stache-code-block>
+    <sky-code-block [code]="npmInstall"></sky-code-block>
   </ng-container>
 
   <ng-content select="sky-demo-page-properties"></ng-content>

--- a/src/app/components/shared/demo-page.component.ts
+++ b/src/app/components/shared/demo-page.component.ts
@@ -2,16 +2,11 @@ import {
   AfterContentInit,
   ChangeDetectionStrategy,
   Component,
-  ContentChildren,
   Input,
-  OnInit,
-  QueryList
+  OnInit
 } from '@angular/core';
 
 import { SkyDemoTitleService } from '../../shared/title.service';
-import { SkyDemoPagePropertiesComponent } from './demo-page-properties.component';
-import { SkyDemoPageExampleComponent } from './demo-page-example.component';
-import { SkyDemoPageContentComponent } from './demo-page-content.component';
 
 @Component({
   selector: 'sky-demo-page',
@@ -19,7 +14,7 @@ import { SkyDemoPageContentComponent } from './demo-page-content.component';
   styleUrls: ['./demo-page.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class SkyDemoPageComponent implements OnInit, AfterContentInit {
+export class SkyDemoPageComponent implements OnInit {
   @Input()
   public pageTitle: string;
 
@@ -51,18 +46,7 @@ export class SkyDemoPageComponent implements OnInit, AfterContentInit {
 
   public npmInstall: string;
 
-  public tableOfContentsRoutes: any[] = [];
-
   public skyuxModulesForDisplay: string[];
-
-  @ContentChildren(SkyDemoPagePropertiesComponent)
-  private propertiesComponents: QueryList<SkyDemoPagePropertiesComponent>;
-
-  @ContentChildren(SkyDemoPageExampleComponent)
-  private exampleComponents: QueryList<SkyDemoPageExampleComponent>;
-
-  @ContentChildren(SkyDemoPageContentComponent)
-  private contentComponents: QueryList<SkyDemoPageContentComponent>;
 
   private _packageName: string;
 
@@ -72,55 +56,6 @@ export class SkyDemoPageComponent implements OnInit, AfterContentInit {
 
   public ngOnInit() {
     this.updateTitle();
-  }
-
-  public ngAfterContentInit(): void {
-    if (this.npmInstall) {
-      this.tableOfContentsRoutes.push({
-        name: 'Installation',
-        fragment: 'installation',
-        path: '.'
-      });
-    }
-
-    this.propertiesComponents.map((component: any) => {
-      this.tableOfContentsRoutes.push({
-        name: component.sectionHeading,
-        fragment: this.getFragment(component.sectionHeading),
-        path: '.'
-      });
-    });
-
-    this.exampleComponents.map((component: any) => {
-      this.tableOfContentsRoutes.push({
-        name: 'Demo',
-        fragment: 'demo',
-        path: '.'
-      });
-    });
-
-    if (this.contentComponents.length) {
-      this.tableOfContentsRoutes.push({
-        name: 'Code',
-        fragment: 'code',
-        path: '.'
-      });
-    }
-
-    this.contentComponents.map((component: any) => {
-      this.tableOfContentsRoutes.push({
-        name: component.sectionHeading,
-        fragment: this.getFragment(component.sectionHeading),
-        path: '.'
-      });
-    });
-  }
-
-  private getFragment(name: string): string {
-    return name
-      .toLowerCase()
-      .replace(/ /g, '-')
-      .replace(/[^\w-]+/g, '');
   }
 
   private updateTitle() {

--- a/src/app/learn/get-started/advanced/accessibility-analyzer/index.html
+++ b/src/app/learn/get-started/advanced/accessibility-analyzer/index.html
@@ -2,7 +2,7 @@
   pageTitle="Accessibility Analyzer (Deprecated)"
   navTitle="Accessibility analyzer"
   showTableOfContents="true">
-  
+
   <stache-page-summary>
   <sky-alert alertType="warning">
     <stache-include fileName="e2e-recommendation.html"></stache-include> If you must use e2e tests, the deprecated accessibility analyzer described here lets you add accessibility checks to e2e specs and manage rules for accessibility. If not, we recommend <a routerLink="/learn/get-started/advanced/accessibility-unit-tests">running accessibility checks in SKY UX unit tests</a>.
@@ -11,57 +11,57 @@
       The SKY UX accessibility analyzer tool allows you to run <a href="https://github.com/dequelabs/axe-core">aXe automated accessibility tests</a> as part of your end-to-end testing. aXe is an open source library of automated accessibility rules that is integrated into SKY UX to identify potential issues for a subset of the <a href="https://www.w3.org/TR/WCAG20/">Web Content Accessibility Guidelines 2.0 Level A and AA success criteria</a>.
     </p>
   </stache-page-summary>
-  
+
   <p>
     To use the accessibility analyzer, you add <stache-code>SkyA11y</stache-code> to e2e specs. And to manage rules for accessibility tests, you use the <stache-code>a11y</stache-code> property in the <stache-code>skyuxconfig.json</stache-code> file.
   </p>
   <p>
     For SKY UX guidance on accessibility best practices, see <a routerLink="/learn/accessibility">accessibility recommendations</a>.
   </p>
-  
+
   <stache-page-anchor>
     Add accessibility analyzer to e2e specs
   </stache-page-anchor>
-  
+
   <p>
     To use the accessibility analyzer in an e2e spec, you manually import the accessibility library at the top of the spec file. This allows you to add the accessibility analyzer anywhere in the e2e spec.
   </p>
-  <stache-code-block>
+  <sky-code-block>
     import { SkyA11y } from '@skyux-sdk/testing;
-  </stache-code-block>
+  </sky-code-block>
   <stache-include fileName="e2e-recommendation-accessibility.html"></stache-include>
 
   <stache-page-anchor>
     Use accessibility analyzer in e2e specs
   </stache-page-anchor>
-  
+
   <p>
     After you import the accessibility library, you can run aXe tests by including the expectation.
   </p>
-  <stache-code-block>
+  <sky-code-block>
     SkyA11y.run().then((violations: number) => {
       expect(violations).toEqual(0);
       done();
     });
-  </stache-code-block>
+  </sky-code-block>
   <p>
     You should include the expectation at any point in your script where you introduce new UI elements into the DOM. For example, include the expectation when pages or views load, when modals or repeater sections open, and when tab panels change.
   </p>
-  
+
   <stache-page-anchor>
     Manage accessibility rules
   </stache-page-anchor>
-  
+
   <p>
     To enable or disable accessibility rules for e2e tests, use the <stache-code>a11y</stache-code> property in the <stache-code>skyuxconfig.json</stache-code> file. You can manage rules individually, or you can enable or disable all rules in bulk. For information about individual rules in aXe automated testing, see <a href="https://github.com/dequelabs/axe-core/blob/master/doc/rule-descriptions.md">the  complete list of accessibility rules</a>.
   </p>
-  
+
   <ul>
     <li>
       <p>
         To disable individual rules, add the <stache-code>a11y</stache-code> property and its <stache-code>rules</stache-code> property. Then list the rules to disable and set <stache-code>enabled</stache-code> to <stache-code>false</stache-code>.
       </p>
-      <stache-code-block>
+      <sky-code-block>
         {
           "a11y": {
             "rules": {
@@ -69,13 +69,13 @@
             }
           }
         }
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
         To enable individual rules that are disabled by default, add the <stache-code>a11y</stache-code> property and its <stache-code>rules</stache-code> property. Then list the rules to enable and set <stache-code>enabled</stache-code> to <stache-code>true</stache-code>.
       </p>
-      <stache-code-block>
+      <sky-code-block>
         {
           "a11y": {
             "rules": {
@@ -83,49 +83,49 @@
             }
           }
         }
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
         To disable all rules, set the <stache-code>a11y</stache-code> property to <stache-code>false</stache-code>.
       </p>
-      <stache-code-block>
+      <sky-code-block>
         {
           "a11y": false
         }
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>To enable all rules, including rules that are disabled by default, set the <stache-code>a11y</stache-code> property to <stache-code>true</stache-code>.</p>
-      <stache-code-block>
+      <sky-code-block>
         {
           "a11y": true
         }
-      </stache-code-block>
+      </sky-code-block>
     </li>
   </ul>
-  
+
   <sky-alert alertType="info">
     For additional guidance on designing, coding, and testing accessible experiences with SKY UX, see <a routerLink="/learn/accessibility">accessibility</a>.
   </sky-alert>
-  
+
   <stache-page-anchor>
     Review accessibility failures
   </stache-page-anchor>
-  
+
   <p>
     When you include accessibility rules in your e2e tests, you may run into errors that uncover accessibility issues. Here is an example of an error message that appears in the command log when you run <stache-code>skyux e2e</stache-code>:
   </p>
-  <stache-code-block>
+  <sky-code-block>
     info: Starting accessibility checks for https://host.nxt.blackbaud.com/builder-allytest/...
     info: Accessibility checks finished with 1 violation.
-    
+
     error: aXe - [Rule: 'label'] Form elements must have labels - WCAG: wcag332, wcag131
     Get help at: https://dequeuniversity.com/rules/axe/2.3/label?application=webdriverjs
     Elements:
-    
+
     <input id="thefirstname" type="text">
-  </stache-code-block>
+  </sky-code-block>
   <p>
     The first line of the error message indicates what failed. It lists the name of the rule that failed and a detailed description that includes the WCAG 2.0 success criteria numbers. On the next line, the error message provides the URL for the rule definition to help address the failure. And finally, the error message lists the DOM elements where the failure was identified.
   </p>

--- a/src/app/learn/get-started/advanced/accessibility-unit-tests/index.html
+++ b/src/app/learn/get-started/advanced/accessibility-unit-tests/index.html
@@ -3,7 +3,7 @@
   navTitle="Accessibility tests"
   showTableOfContents="true"
   navOrder="1">
-  
+
   <stache-page-summary>
     <p>
       The <a href="https://github.com/blackbaud/skyux-sdk-testing">SKY UX SDK testing library</a> provides methods to run <a href="https://github.com/dequelabs/axe-core">aXe automated accessibility tests</a> in your unit tests. aXe is an open source library of automated accessibility rules that is integrated into SKY UX to identify potential issues for a subset of the <a href="https://www.w3.org/TR/WCAG20/">Web Content Accessibility Guidelines 2.0 Level A and AA success criteria</a>. For SKY UX guidance on designing, coding, and testing accessible experiences, see the accessibility section.
@@ -13,80 +13,80 @@
   <p>
     <stache-include fileName="e2e-recommendation.html"></stache-include> If you must use e2e tests, the deprecated accessibility analyzer lets you add accessibility checks to e2e specs and manage rules for accessibility tests with an <stache-code>a11y</stache-code> configuration property. For more information, see <a routerLink="/learn/get-started/advanced/accessibility-analyzer">the accessibility analyzer</a> and <a routerLink="/learn/reference/configuration">the configuration guidelines</a>.
   </p>
-  
+
   <stache-page-anchor>
     Import SKY UX SDK testing library
   </stache-page-anchor>
-  
+
   <p>
     The first step to run accessibility checks in SKY UX unit tests is to import the <a href="https://github.com/blackbaud/skyux-sdk-testing">SKY UX SDK testing library</a> into your SPA. This library provides methods to interact with SKY UX during Karma unit tests. For accessibility testing, it extends the Jasmine <stache-code>expect</stache-code> function to add the <stache-code>toBeAccessible</stache-code> matcher.
   </p>
   <p>
     To install the testing library, open the command prompt, <stache-code>cd</stache-code> into your SPA's directory, and run:
   </p>
-  <stache-code-block>
+  <sky-code-block>
     npm install @blackbaud/skyux-sdk-testing --save-dev --save-exact
-  </stache-code-block>
+  </sky-code-block>
   <p>
     By default, the <stache-code>SkyA11yAnalyzerConfig</stache-code> interface specifies <a href="https://github.com/blackbaud/skyux-sdk-testing/blob/master/src/app/public/a11y/a11y-analyzer.ts">configuration settings for <stache-code>toBeAccessible</stache-code> to indicate which accessibility checks to run</a>. To overwrite the default acccessibility checks, you can modify <a stacheRouterLink="." fragment="specify-parameters-for-tobeaccessible">a parameter for the <stache-code>toBeAccessible</stache-code> matcher</a>.
   </p>
-  
+
 
   <stache-page-anchor>
     Import the <stache-code>expect</stache-code> function
   </stache-page-anchor>
-  
+
   <p>
     After you import the testing library, the next step to run accessibility checks in unit tests is to import the extended Jasmine <stache-code>expect</stache-code> function into <stache-code>.spec.ts</stache-code> files. At the top of the spec files for the components to test, import the function from the testing library:
   </p>
-  <stache-code-block>
+  <sky-code-block>
     import {
       expect
     } from '@blackbaud/skyux-sdk-testing';
-  </stache-code-block>
+  </sky-code-block>
   <p>
-    After you import <stache-code>expect</stache-code> function, you can use it to run accessibility tests for components. For components that change state, you can insert the function into existing <stache-code>it</stache-code> blocks. And for components that don't change state, the function can stand alone to run accessibility checks from its own <stache-code>it</stache-code> block. 
+    After you import <stache-code>expect</stache-code> function, you can use it to run accessibility tests for components. For components that change state, you can insert the function into existing <stache-code>it</stache-code> blocks. And for components that don't change state, the function can stand alone to run accessibility checks from its own <stache-code>it</stache-code> block.
   </p>
-  
+
   <stache-page-anchor>
     Insert the <stache-code>expect</stache-code> function and <stache-code>toBeAccessible</stache-code> matcher
   </stache-page-anchor>
-  
+
   <p>
-    After you import the <stache-code>expect</stache-code> function into spec files, the next step is to wrap the <stache-code>expect</stache-code> function around the elements to test for accessibility. Accessibility checks are asynchronous, so it's important to wrap your tests in Angular's <stache-code>async</stache-code> method. And to break the linear flow of control when using <stache-code>async</stache-code>, it's also important to wrap <stache-code>toBeAccessible</stache-code> in Angular's <stache-code>whenStable</stache-code> method. 
+    After you import the <stache-code>expect</stache-code> function into spec files, the next step is to wrap the <stache-code>expect</stache-code> function around the elements to test for accessibility. Accessibility checks are asynchronous, so it's important to wrap your tests in Angular's <stache-code>async</stache-code> method. And to break the linear flow of control when using <stache-code>async</stache-code>, it's also important to wrap <stache-code>toBeAccessible</stache-code> in Angular's <stache-code>whenStable</stache-code> method.
   </p>
-  
-  <stache-code-block>
+
+  <sky-code-block>
     it('should pass accessibility', async(() => {
       fixture.whenStable().then(() => {
         expect(element).toBeAccessible();
       });
     }));
-  </stache-code-block>
+  </sky-code-block>
 
   <p>
     Keep in mind that <stache-code>async</stache-code> is also a native JavaScript declaration, so you need to explicitly import the Angular <stache-code>async</stache-code> method at the top of the unit test spec file.
   </p>
 
-  <stache-code-block>
+  <sky-code-block>
     import { async } from ‘@angular/core/testing’;
-  </stache-code-block>
-  
+  </sky-code-block>
+
   <stache-page-anchor>
     Specify parameters for <stache-code>toBeAccessible</stache-code>
   </stache-page-anchor>
-  
+
   <p>
-    Finally, you can specify two optional parameters within the <stache-code>toBeAccessible</stache-code> matcher. The first parameter is a callback that lets you execute code after accessibility checks run. The second parameter is an option that lets you overwrite <a href="https://github.com/blackbaud/skyux-sdk-testing/blob/master/src/app/public/a11y/a11y-analyzer.ts">the default accessibility checks that <stache-code>SkyA11yAnalyzerConfig</stache-code> specifies</a>. 
+    Finally, you can specify two optional parameters within the <stache-code>toBeAccessible</stache-code> matcher. The first parameter is a callback that lets you execute code after accessibility checks run. The second parameter is an option that lets you overwrite <a href="https://github.com/blackbaud/skyux-sdk-testing/blob/master/src/app/public/a11y/a11y-analyzer.ts">the default accessibility checks that <stache-code>SkyA11yAnalyzerConfig</stache-code> specifies</a>.
   </p>
 
   <h3 class="sky-subsection-heading">
     Callback
   </h3>
   <p>
-    In the first <stache-code>toBeAccessible</stache-code> parameter, you can specify logic to run after accessibility testing: 
+    In the first <stache-code>toBeAccessible</stache-code> parameter, you can specify logic to run after accessibility testing:
   </p>
-  <stache-code-block>
+  <sky-code-block>
     it('should pass accessibility', async(() => {
       fixture.whenStable().then(() => {
         expect(element).toBeAccessible(() => {
@@ -94,7 +94,7 @@
         });
       });
     }));
-  </stache-code-block>
+  </sky-code-block>
   <p>
     For example, for components that change state, you can use this parameter to change state after accessibility checks and then run the accessibility checks again.
   </p>
@@ -105,7 +105,7 @@
   <p>
     In the second <stache-code>toBeAccessible</stache-code> parameter, you can adjust configuration settings to turn off accessibility checks. <a href="https://github.com/blackbaud/skyux-sdk-testing/blob/master/src/app/public/a11y/a11y-analyzer.ts">The <stache-code>SkyA11yAnalyzerConfig</stache-code> interface</a> specifies configuration settings, and it turns all checks on by default. To turn off accessibility checks, you set them to <stache-code>false</stache-code>:
   </p>
-  <stache-code-block>
+  <sky-code-block>
     it('should pass accessibility', async(() => {
       fixture.whenStable().then(() => {
         expect(element).toBeAccessible(() => {}, {
@@ -115,14 +115,14 @@
         });
       });
     }));
-  </stache-code-block>
+  </sky-code-block>
   <p>
     You can also use the SKY UX <stache-code>a11y</stache-code> configuration property to overwrite accessibility checks. This option is useful if you need to turn off a set of accessibility checks in multiple spec files.
   </p>
   <p>
     In the <stache-code>skyuxconfig.json</stache-code> file, you specify the accessibility checks to overwrite and set them to <stache-code>false</stache-code>:
   </p>
-  <stache-code-block>
+  <sky-code-block>
     {
       "a11y": {
         "rules": {
@@ -132,11 +132,11 @@
         }
       }
     }
-  </stache-code-block>
+  </sky-code-block>
   <p>
     Then in the spec files where you want to overwrite accessibility checks, you import <stache-code>SkyAppConfig</stache-code> and <stache-code>SkyAppTest</stache-code> at the top:
   </p>
-  <stache-code-block>
+  <sky-code-block>
     import {
       SkyAppConfig
     } from '@skyux/config';
@@ -144,11 +144,11 @@
     import {
       SkyAppTestModule
     } from '@skyux-sdk/builder/runtime/testing/browser';
-  </stache-code-block>
+  </sky-code-block>
   <p>
     Finally, in the <stache-code>it</stache-code> blocks where you run accessibility checks, you inject <stache-code>SkyAppConfig</stache-code> in the <stache-code>async</stache-code> method and then reference the <stache-code>a11y</stache-code> configuration property in the second <stache-code>toBeAccessible</stache-code> parameter:
   </p>
-  <stache-code-block>
+  <sky-code-block>
     it('should pass accessibility', async(
       inject([SkyAppConfig], (appConfig: SkyAppConfig) => {
         fixture.whenStable().then(() => {
@@ -156,25 +156,25 @@
         });
       }))
     );
-  </stache-code-block>
-  
+  </sky-code-block>
+
   <stache-page-anchor>
     Review accessibility failures
   </stache-page-anchor>
-  
+
   <p>
     When you include accessibility rules in your unit tests, you may run into errors that uncover accessibility issues. Here is an example of an error message that appears in the command log when you run <stache-code>skyux test</stache-code>:
   </p>
-  <stache-code-block>
+  <sky-code-block>
     info: Starting accessibility checks for https://host.nxt.blackbaud.com/builder-allytest/...
     info: Accessibility checks finished with 1 violation.
-    
+
     error: aXe - [Rule: 'label'] Form elements must have labels - WCAG: wcag332, wcag131
     Get help at: https://dequeuniversity.com/rules/axe/2.3/label?application=webdriverjs
     Elements:
-    
+
     <input id="thefirstname" type="text">
-  </stache-code-block>
+  </sky-code-block>
   <p>
     The first line of the error message indicates what failed. It lists the name of the rule that failed and a detailed description that includes the WCAG 2.0 success criteria numbers. On the next line, the error message provides the URL for the rule definition to help address the failure. And finally, the error message lists the DOM elements where the failure was identified.
   </p>

--- a/src/app/learn/get-started/advanced/add-entry-components/index.html
+++ b/src/app/learn/get-started/advanced/add-entry-components/index.html
@@ -28,11 +28,11 @@
       <p>
         In the new <stache-code>modal</stache-code> folder, create a file and name it <stache-code>index.html</stache-code>. Place the shared <stache-code>app-nav</stache-code> component at the top and then add hello world content.
       </p>
-      <stache-code-block languageType="markup">
+      <sky-code-block languageType="markup">
         <app-nav></app-nav>
         <h1>Modal launch page</h1>
         <p>This page displays a button to launch a modal.</p>
-      </stache-code-block>
+      </sky-code-block>
       <p>
         The <stache-code>app-nav</stache-code> component is an example of a shared component. It manually creates top-level navigation within your app.
       </p>
@@ -51,7 +51,7 @@
       <p>
         Add a path for the new page with <stache-code>name</stache-code> set to "Modal" and <stache-code>path</stache-code> set to "/modal." The <stache-code>name</stache-code> provides the label for the menu, and the <stache-code>path</stache-code> specifies the name of the folder.
       </p>
-<stache-code-block languageType="typescript">
+<sky-code-block languageType="typescript">
 import { Component } from '@angular/core';
 
 @Component({
@@ -79,7 +79,7 @@ export class AppNavComponent {
     }
   ];
 }
-</stache-code-block>
+</sky-code-block>
     </li>
     <li>
       <p>
@@ -90,11 +90,11 @@ export class AppNavComponent {
       <p>
         In the <stache-code>modal</stache-code> folder, add another new file and name it <stache-code>modal-demo-context.ts</stache-code>. Add the following code:
       </p>
-      <stache-code-block>
+      <sky-code-block>
        export class SkyModalDemoContext {
           public value1: string;
       }
-      </stache-code-block>
+      </sky-code-block>
       <p>
         This file passes a context object to the modal to prepopulate the modal field. In this sample, we prepopulate dummy data, but in a production modal, you can pull data from records and use this file can supply the context to determine what data to populate based on what record the form opens from.
       </p>
@@ -108,7 +108,7 @@ export class AppNavComponent {
       <p>
         In the <stache-code>modal</stache-code> folder, add another new file and name it <stache-code>modal-demo-launcher.component.ts</stache-code>. This file defines the button component that launches the modal and its functionality. Add the following code:
       </p>
-<stache-code-block languageType="typescript">
+<sky-code-block languageType="typescript">
 import { Component } from '@angular/core';
 
 import { SkyModalService, SkyModalCloseArgs } from '@blackbaud/skyux/dist/core';
@@ -141,7 +141,7 @@ export class SkyModalDemoComponent {
     });
   }
 }
-</stache-code-block>
+</sky-code-block>
       <p>
         The <stache-code>import</stache-code> entries import several items:
       </p>
@@ -160,7 +160,7 @@ export class SkyModalDemoComponent {
           The <stache-code>SkyModalDemoFormComponent</stache-code> class from the <stache-code>modal-demo-form.component.ts</stache-code> file that we still need to create provides a header and constructs the modal instance.
         </li>
       </ul>
-      
+
       <p>
         The <stache-code>@Component</stache-code> section is a decorator for the component, and it defines our selector and template. The decorator takes normal JavaScript classes and  extends the JavaScript functionality to convert them into Angular components.
       </p>
@@ -177,11 +177,11 @@ export class SkyModalDemoComponent {
       <p>
         In the <stache-code>modal</stache-code> folder, add another new file and name it <stache-code>modal-demo-launcher.component.html</stache-code>. This file serves as the template for the button component that launches the modal form. Add the following code:
       </p>
-      <stache-code-block langaugeType="markup">
+      <sky-code-block langaugeType="markup">
         <button type="button" class="sky-btn sky-btn-primary" (click)="openModal()">
           Open modal
         </button>
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
@@ -192,7 +192,7 @@ export class SkyModalDemoComponent {
       <p>
         In the <stache-code>modal</stache-code> folder, add another new file and name it <stache-code>modal-demo-form.component.ts</stache-code>. This file defines the modal form component and its functionality. Add the following code:
       </p>
-<stache-code-block languageType="typescript">
+<sky-code-block languageType="typescript">
 import { Component } from '@angular/core';
 
 import { SkyModalInstance } from '@blackbaud/skyux/dist/core';
@@ -208,11 +208,11 @@ export class SkyModalDemoFormComponent {
 
   constructor(public context: SkyModalDemoContext, public instance: SkyModalInstance) { }
 }
-</stache-code-block>
+</sky-code-block>
       <p>
         The <stache-code>import</stache-code> commands import several items:
       </p>
-      
+
       <ul>
         <li>
           The <stache-code>Component</stache-code> class from Angular provides functionality to the component that we are defining.
@@ -224,7 +224,7 @@ export class SkyModalDemoFormComponent {
           The <stache-code>SkyModalDemoContext</stache-code> class from the <stache-code>modal-demo-context.ts</stache-code> file that we created passes a context object to prepopulate the modal field.
         </li>
       </ul>
-      
+
       <p>
         The <stache-code>@Component</stache-code> section is a decorator for the component, and it defines our selector and template. The decorator takes normal JavaScript classes and  extends the JavaScript functionality to convert them into Angular components.
       </p>
@@ -241,7 +241,7 @@ export class SkyModalDemoFormComponent {
       <p>
         In the <stache-code>modal</stache-code> folder, add another new file and name it <stache-code>modal-demo-form.component.html</stache-code>. This file will serve as the template for the modal component. Add the following code:
       </p>
-      <stache-code-block languageType="markup">
+      <sky-code-block languageType="markup">
         <sky-modal>
           <sky-modal-header>
             {{title}}
@@ -262,7 +262,7 @@ export class SkyModalDemoFormComponent {
             </button>
           </sky-modal-footer>
         </sky-modal>
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
@@ -271,7 +271,7 @@ export class SkyModalDemoFormComponent {
       <p>
         In the <stache-code>entryComponents</stache-code> property, add an entry to register the modal as an entry component.
       </p>
-<stache-code-block languageType="typescript">
+<sky-code-block languageType="typescript">
 import { NgModule } from '@angular/core';
 
 import { SkyModalDemoFormComponent } from './modal/modal-demo-form.component';
@@ -284,7 +284,7 @@ import { SkyModalDemoFormComponent } from './modal/modal-demo-form.component';
   ]
 })
 export class AppExtrasModule { }
-</stache-code-block>
+</sky-code-block>
     </li>
     <li>
       <p>
@@ -294,12 +294,12 @@ export class AppExtrasModule { }
     <li>
       <p>Return to the <stache-code>index.html</stache-code> file, and add the <stache-code>sky-modal-demo-launcher</stache-code> selector that we defined in the <stache-code>modal-demo-context.ts</stache-code> file.
       </p>
-      <stache-code-block languageType="markup">
+      <sky-code-block languageType="markup">
         <app-nav></app-nav>
         <h1>Modal launch page</h1>
         <p>This page displays a button to launch a modal.</p>
         <sky-modal-demo-launcher></sky-modal-demo-launcher>
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>

--- a/src/app/learn/get-started/advanced/include-static-assets/index.html
+++ b/src/app/learn/get-started/advanced/include-static-assets/index.html
@@ -8,7 +8,7 @@
       To include static assets such as images in your SPA, you place them in the <stache-code>assets</stache-code> folder in the <stache-code>src</stache-code> directory. You can then reference the files in your HTML, CSS, or SCSS. If you need programmatic access to the files, you can use the <stache-code>SkyAppAssetsService</stache-code>. For more information about static assets, see the <stache-code>src/assets</stache-code> entry in <a routerLink="/learn/reference/naming-and-placement">the file name and placement reference.
     </p>
   </stache-page-summary>
-  
+
   <stache-page-anchor>
     Include a static asset on a page
   </stache-page-anchor>
@@ -29,15 +29,15 @@
       <p>
         For example, you can display an image on a page.
       </p>
-      <stache-code-block>
+      <sky-code-block>
         <p>
           <img src="&#126;/assets/img/example.jpg" alt="Photo" />
         </p>
-      </stache-code-block>
+      </sky-code-block>
       <p>
         Or you can insert an image in the background.
       </p>
-      <stache-code-block languageType="typescript">
+      <sky-code-block languageType="typescript">
         <div [ngStyle]="{
           'background-image': 'url(&#126;/assets/img/example.jpg)',
           'height': '500px',
@@ -45,7 +45,7 @@
         }">
           Foreground content goes here
         </div>
-      </stache-code-block>
+      </sky-code-block>
     </li>
   </ol>
 
@@ -54,7 +54,7 @@
   </stache-page-anchor>
 
   <p>
-    For programmatic access to static assets during runtime outside of your template, you can use the <stache-code>SkyAppAssetsService</stache-code>. The service's only method is <stache-code>getUrl</stache-code>, which takes a string value with the path and file name, relative to the <stache-code>assets</stache-code> folder. 
+    For programmatic access to static assets during runtime outside of your template, you can use the <stache-code>SkyAppAssetsService</stache-code>. The service's only method is <stache-code>getUrl</stache-code>, which takes a string value with the path and file name, relative to the <stache-code>assets</stache-code> folder.
   </p>
   <ol>
     <li>
@@ -66,25 +66,25 @@
       <p>
         In the file where you want to access the static asset, import <stache-code>SkyAppAssetsService</stache-code>.
       </p>
-      <stache-code-block languageType="typescript">
+      <sky-code-block languageType="typescript">
         import { SkyAppAssetsService } from '@skyux/assets;
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
         In the <stache-code>getUrl</stache-code> method, specify the path and file name for the static asset.
       </p>
-      <stache-code-block>
+      <sky-code-block>
         skyAppAssetsService.getUrl('json/example.json')
-      </stache-code-block>
+      </sky-code-block>
       <p>
         For example, you can use the <stache-code>SkyAppAssetsService</stache-code> to display data from a JSON file.
       </p>
-      <stache-code-block languageType="typescript">
+      <sky-code-block languageType="typescript">
         import { Component } from '@angular/core';
         import { Http } from '@angular/http';
         import { SkyAppAssetsService } from '@skyux/assets;
-        
+
         @Component({
           selector: 'my-home',
           templateUrl: './home.component.html'
@@ -101,9 +101,9 @@
               });
           }
         }
-      </stache-code-block>
+      </sky-code-block>
     </li>
   </ol>
 
-  
+
 </stache>

--- a/src/app/learn/get-started/advanced/localization/index.html
+++ b/src/app/learn/get-started/advanced/localization/index.html
@@ -7,7 +7,7 @@
       SKY UX Builder provides the capability to declare localization strings <a routerLink="/learn/reference/naming-and-placement">in a JSON file </a> and then reference those strings throughout your SPA using the <stache-code>skyAppResources</stache-code> pipe or the <stache-code>SkyAppResourcesService</stache-code> service in <stache-code>@skyux/i18n</stache-code>.
     </p>
   </stache-page-summary>
-    
+
   <sky-alert alertType="info">
     SKY UX Builder version <stache-code>1.14</stache-code> or later is required for a library to provide its own resource files. The consuming SPA must also be on version <stache-code>1.14</stache-code> or later.
   </sky-alert>
@@ -26,14 +26,14 @@
       <p>
         Declare the localization strings to reuse throughout your SPA. Using JSON structure, specify a string name and then provide the string and a description.
       </p>
-      <stache-code-block languageType="markup">
+      <sky-code-block languageType="markup">
         {
           "string_name": {
             "message": "The localization string",
             "_description": "A description of the string for the translator."
           }
         }
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
@@ -45,20 +45,20 @@
           <p>
             For the <stache-code>skyAppResources</stache-code> pipe, pull the string into your template by name.
           </p>
-          <stache-code-block>
+          <sky-code-block>
             {{ 'string_name' | skyAppResources }}
-          </stache-code-block>
+          </sky-code-block>
         </li>
         <li>
           <p>
             For the <stache-code>SkyAppResourcesService</stache-code> service in <stache-code>@bskyux/i18n</stache-code>, pull the string using <stache-code>getString</stache-code>.
           </p>
-          <stache-code-block>
+          <sky-code-block>
             this.resources.getString('string_name')
               .subscribe((value) => {
                 /*do something with the string*/
             });
-          </stache-code-block></li>
+          </sky-code-block></li>
       </ul>
     </li>
   </ol>
@@ -77,14 +77,14 @@
       <p>
         Declare templated localization strings with .NET-style tokens in the string that you can replace with dynamic values. For example:
       </p>
-      <stache-code-block languageType="markup">
+      <sky-code-block languageType="markup">
         {
           "string_name": {
             "message": "{0} gave money to the {1} fund",
             "_description": "A string with .NET-style tokens to replace with constituentName and fundName."
           }
         }
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
@@ -96,20 +96,20 @@
           <p>
             For the <stache-code>skyAppResources</stache-code> pipe, place <stache-code>{{ 'string_name' | skyAppResources }}</stache-code> in your template and insert values for the .NET-style tokens. For example:
           </p>
-          <stache-code-block>
+          <sky-code-block>
             {{ 'string_name' | skyAppResources:constituentName:fundName }}
-          </stache-code-block>
+          </sky-code-block>
         </li>
         <li>
           <p>
             For the <stache-code>SkyAppResourcesService</stache-code> service in <stache-code>@skyux/i18n</stache-code>, pull the string using <stache-code>getString</stache-code> and insert values for the .NET-style tokens. For example:
           </p>
-          <stache-code-block>
+          <sky-code-block>
             this.resources.getString('string_name',constituentName,fundName)
               .subscribe((value) => {
                 /*do something with the string*/
             });
-          </stache-code-block>
+          </sky-code-block>
         </li>
       </ul>
     </li>
@@ -130,11 +130,11 @@
   <p>
     If your application determines the locale through a different mechanism, such as a setting stored in a database, you can provide a custom implementation of the <stache-code>SkyAppLocaleProvider</stache-code>.
   </p>
-  
+
   <p>
     For example, here is a sample <stache-code>app-extras.module.ts</stache-code> file:
   </p>
-  <stache-code-block languageType="typescript">
+  <sky-code-block languageType="typescript">
 import { NgModule } from '@angular/core';
 import { TestLocaleProvider } from './test-locale-provider'
 
@@ -145,11 +145,11 @@ import { TestLocaleProvider } from './test-locale-provider'
   }]
 })
 export class AppExtrasModule { }
-  </stache-code-block>
+  </sky-code-block>
   <p>
     And here is a sample <stache-code>test-locale-provider.ts</stache-code> file:
   </p>
-  <stache-code-block languageType="typescript">
+  <sky-code-block languageType="typescript">
 import { NgModule } from '@angular/core';
 import { SkyAppLocaleProvider } from '@skyux/i18n';
 import { Observable } from 'rxjs/Observable';
@@ -161,6 +161,6 @@ export class TestLocaleProvider extends SkyAppLocaleProvider {
     });
   }
 }
-  </stache-code-block>
-  
+  </sky-code-block>
+
 </stache>

--- a/src/app/learn/get-started/advanced/module-level-providers/index.html
+++ b/src/app/learn/get-started/advanced/module-level-providers/index.html
@@ -12,7 +12,7 @@
   <sky-alert alertType="warning">
     In the code sample, we add <stache-code>DragulaModule</stache-code> to both the <stache-code>imports</stache-code> and <stache-code>exports</stache-code> properties of <stache-code>AppExtrasModule</stache-code> because <stache-code>app-extras.module.ts</stache-code> is not the application's root module.
   </sky-alert>
-  <stache-code-block languageType="typescript">
+  <sky-code-block languageType="typescript">
     import { NgModule } from '@angular/core';
     import { DragulaService, DragulaModule } from 'ng2-dragula/ng2-dragula';
 
@@ -30,6 +30,6 @@
       entryComponents: []
     })
     export class AppExtrasModule { }
-  </stache-code-block>
+  </sky-code-block>
 
 </stache>

--- a/src/app/learn/get-started/advanced/pact-tests/index.html
+++ b/src/app/learn/get-started/advanced/pact-tests/index.html
@@ -12,19 +12,19 @@
   <stache-page-anchor>
     Configure pact settings
   </stache-page-anchor>
-  
+
   <p>
     The first step to implement pact testing for a SPA is to specify configuration options <a routerLink="/learn/reference/configuration">with the <stache-code>pacts</stache-code> property in the <stache-code>skyuxconfig.json</stache-code> file</a>. In this property, you create a separate entry for each provider to test. Settings are generally the same for each entry except for the <stache-code>provider</stache-code> setting. When you run <stache-code>skyux pact</stache-code>, the command reads the <stache-code>pacts</stache-code> setting and spins up an individual pact server for each provider service that you specify.
   </p>
   <p>
-    For each service provider that you need to configure settings for, you can include the following properties: 
+    For each service provider that you need to configure settings for, you can include the following properties:
   </p>
   <ul>
     <li>
       <p>
         To specify the consumer and provider of a service, add the <stache-code>consumer</stache-code> and <stache-code>provider</stache-code> settings. The provider is the service that exposes an API, while the consumer is the component or service in the SPA that calls the provider's API.
       </p>
-      <stache-code-block>
+      <sky-code-block>
         {
           "pacts": [
             {
@@ -33,13 +33,13 @@
             }
           ]
         }
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
         To specify a host and port to use for pact tests, add the <stache-code>host</stache-code> and <stache-code>port</stache-code> settings. By default, the host is <stache-code>localhost</stache-code> and SKY UX Builder dynamically finds the next available port.
       </p>
-      <stache-code-block>
+      <sky-code-block>
         {
           "pacts": [
             {
@@ -50,13 +50,13 @@
             }
           ]
         }
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
         To specify a directory for the pact file that the pact server generates to describe the behaviors that the consumer expects from the provider service, add the <stache-code>dir</stache-code> setting. By default, the pact server stores the JSON file in the <stache-code>app/pacts</stache-code> directory.
       </p>
-      <stache-code-block>
+      <sky-code-block>
         {
           "pacts": [
             {
@@ -68,7 +68,7 @@
             }
           ]
         }
-        </stache-code-block>
+        </sky-code-block>
     <li>
       <p>
         Configure the log file as necessary:
@@ -88,7 +88,7 @@
           </p>
         </li>
       </ul>
-      <stache-code-block>
+      <sky-code-block>
         {
           "pacts": [
             {
@@ -103,7 +103,7 @@
             }
           ]
         }
-        </stache-code-block>
+        </sky-code-block>
     </li>
   </ul>
   <p>
@@ -129,19 +129,19 @@
   <ul>
     <li>
       <p>
-        To create the pact test, add a new file with a filename that ends with <stache-code>.pact-spec.ts</stache-code>. SKY UX automatically configures Karma to run pact tests in the <stache-code>src/app</stache-code> folder that match the <stache-code>.pact-spec.ts</stache-code> pattern. We recommend that SKY UX pact tests use the same name as the components or services where they test integration with consumed services and that you place the spec files in the same folder as the components or services that they test. 
+        To create the pact test, add a new file with a filename that ends with <stache-code>.pact-spec.ts</stache-code>. SKY UX automatically configures Karma to run pact tests in the <stache-code>src/app</stache-code> folder that match the <stache-code>.pact-spec.ts</stache-code> pattern. We recommend that SKY UX pact tests use the same name as the components or services where they test integration with consumed services and that you place the spec files in the same folder as the components or services that they test.
       </p>
     </li>
     <li>
       <p>
         In the pact test file, create a <stache-code>beforeAll</stache-code> block. Within the <stache-code>beforeAll</stache-code> block, import <stache-code>SkyAppTestModule</stache-code> and provide access to <stache-code>SkyPactService</stache-code>. <stache-code>SkyPactService</stache-code> allows you to interact with the pact server from within a unit test, which allows you to test endpoints without end-to-end tests.
       </p>
-      <stache-code-block>
+      <sky-code-block>
         TestBed.configureTestingModule({
           imports: [SkyAppTestModule]
           });
           skyPactService = TestBed.get(SkyPactService);
-      </stache-code-block>
+      </sky-code-block>
       <p>
         With the <stache-code>beforeAll</stache-code> block in place, you can call <stache-code>skyPactService.addInteraction(&#123;provider-name-here}, &#123;})</stache-code>.</p>
       <p>
@@ -160,7 +160,7 @@
           <p>
             Call the <stache-code>addInteraction</stache-code> method with an input similar to this:
           </p>
-          <stache-code-block>
+          <sky-code-block>
             {
               uponReceiving: '{description}',
               state: `{provider_state}`,
@@ -179,7 +179,7 @@
                 }
               }
             }
-          </stache-code-block>
+          </sky-code-block>
         </li>
         <li>
           <p>
@@ -208,7 +208,7 @@
     After you create your pact tests, the next step is to run the tests from the SKY UX CLI to confirm integration between provider services and your SPA. From the command prompt, navigate to your SPA's directory and run <a routerLink="/learn/reference/cli-commands/pact">the <stache-code>skyux pact</stache-code> command</a>.
   </p>
   <p>
-    SKY UX automatically configures Karma to run all pact tests in the <stache-code>src/app</stache-code> folder that match the <stache-code>.pact-spec.ts</stache-code> pattern. The <stache-code>pact</stache-code> command spins up an individual pact server for each provider, as well as one for the proxy server. The proxy server takes requests from the browser that runs in the host and port specified in your configuration settings, and it changes the CORS headers to the <stache-code>url</stache-code> value in the <stache-code>host</stache-code> property of <stache-code>skyuxconfig.json</stache-code>, which defaults to <stache-code>https://host.nxt.blackbaud.com</stache-code>. 
+    SKY UX automatically configures Karma to run all pact tests in the <stache-code>src/app</stache-code> folder that match the <stache-code>.pact-spec.ts</stache-code> pattern. The <stache-code>pact</stache-code> command spins up an individual pact server for each provider, as well as one for the proxy server. The proxy server takes requests from the browser that runs in the host and port specified in your configuration settings, and it changes the CORS headers to the <stache-code>url</stache-code> value in the <stache-code>host</stache-code> property of <stache-code>skyuxconfig.json</stache-code>, which defaults to <stache-code>https://host.nxt.blackbaud.com</stache-code>.
   </p>
 
 </stache>

--- a/src/app/learn/get-started/advanced/route-params/index.html
+++ b/src/app/learn/get-started/advanced/route-params/index.html
@@ -9,20 +9,20 @@
   <p>
     To create a route parameter, you create a subfolder and prefix its name with an underscore. The subfolder name must be a valid TypeScript variable because SKY UX Builder creates a <stache-code>string</stache-code> variable with that name (minus the underscore). For example, if you create a page at <stache-code>src/app/dogs</stache-code> for users to view dogs that are up for adoption, you can use route parameters to display individual dogs by creating a <stache-code>src/app/dogs/_id</stache-code> subfolder and adding an <stache-code>index.html</stache-code> file with the following content:
   </p>
-  <stache-code-block>
+  <sky-code-block>
     You are viewing dog {{ id }}.
-  </stache-code-block>
+  </sky-code-block>
   <p>
     When users visit the route <stache-code>dogs/42</stache-code>, the <stache-code>id</stache-code> variable is set to "42" and renders as:
   </p>
-  <stache-code-block>
+  <sky-code-block>
     You are viewing dog 42.
-  </stache-code-block>
+  </sky-code-block>
   <p>
     You can create routes with multiple route parameters by setting up nested parameter folders. For example, in the dogs example, you may you want to group dogs by their shelter locations. To do this, you can create a <stache-code>location</stache-code> folder with a <stache-code>_name</stache-code> subfolder and move the <stache-code>dogs</stache-code> folder and its <stache-code>_id</stache-code> subfolder within that path: <stache-code>src/app/location/_name/dogs/_id</stache-code>.
   </p>
   <p>
-    We recommend against creating paramaterized routes as siblings of static routes. Nesting paramaterized routes alongside static routes is not a problem, but when paramaterized routes and static routes are siblings, it can create ambiguity for the router. 
+    We recommend against creating paramaterized routes as siblings of static routes. Nesting paramaterized routes alongside static routes is not a problem, but when paramaterized routes and static routes are siblings, it can create ambiguity for the router.
   </p>
 
   <stache-page-anchor>
@@ -42,7 +42,7 @@
       <p>
         In <stache-code>about.service.ts</stache-code>, add data to the shared service so that multiple components can use it. First, import <stache-code>Injectable</stache-code> from Angular. Then copy the <stache-code>AboutService</stache-code> data from the <stache-code>about.component.ts</stache-code> file in <stache-code>src/app/about</stache-code> and update it to replace the public <stache-code>team</stache-code> method with a private <stache-code>users</stache-code> method and add <stache-code>id</stache-code> properties for each user. Then expose public methods to read the data.
       </p>
-      <stache-code-block languageType="typescript">
+      <sky-code-block languageType="typescript">
 import { Injectable } from '@angular/core';
 
 @Injectable()
@@ -69,13 +69,13 @@ export class AboutService {
 
   public getUserById = (id: string) => this.users.filter(user => user.id === id)[0];
 }
-</stache-code-block>
+</sky-code-block>
     </li>
     <li>
       <p>
         In the <stache-code>about.component.ts</stache-code> file in <stache-code>src/app/about</stache-code>, import <stache-code>AboutService</stache-code> and update the public <stache-code>team</stache-code> method so that we can declare it in the constructor and use it to get users. We can also remove data from the public <stache-code>team</stache-code> method.
       </p>
-      <stache-code-block languageType="typescript">
+      <sky-code-block languageType="typescript">
 import { Component } from '@angular/core';
 import { AboutService } from '../shared/about.service';
 
@@ -92,13 +92,13 @@ export class AboutComponent {
     this.team = aboutService.getUsers();
   }
 }
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
         In the <stache-code>app-extras.module.ts</stache-code> file in <stache-code>src/app</stache-code>, import <stache-code>AboutService</stache-code> and add it to the <stache-code>providers</stache-code> array.
       </p>
-      <stache-code-block languageType="typescript">
+      <sky-code-block languageType="typescript">
 import { NgModule } from '@angular/core';
 import { AboutService } from './shared/about.service';
 
@@ -110,7 +110,7 @@ import { AboutService } from './shared/about.service';
   entryComponents: []
 })
 export class AppExtrasModule { }
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
@@ -120,7 +120,7 @@ export class AppExtrasModule { }
       <p>
         In the <stache-code>_id</stache-code> subfolder, add <stache-code>about-user.component.ts</stache-code> to create a component. We need to import <stache-code>Component</stache-code>, <stache-code>Input</stache-code>, and <stache-code>OnInit</stache-code> from Angular and also <stache-code>AboutService</stache-code>. After we define the component's selector and template, we can define the component class and the public <stache-code>userId</stache-code> and <stache-code>user</stache-code> input variables. We'll use <stache-code>userId</stache-code> to pass the ID into the component. Since we don't know when the <stache-code>userId</stache-code> property will be set or who will set it, we'll use the <stache-code>getter/setter</stache-code> technique to accommodate the value changing.
       </p>
-      <stache-code-block languageType="typescript">
+      <sky-code-block languageType="typescript">
 import {
   Component,
   Input,
@@ -152,13 +152,13 @@ export class AboutUserComponent {
     private aboutService: AboutService
   ) { }
 }
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
         In the <stache-code>_id</stache-code> subfolder, add <stache-code>about-user.component.html</stache-code> to create a template for the component. On the template, we can display the user name and email along with a link to the About page.
       </p>
-      <stache-code-block>
+      <sky-code-block>
 <h1>
   <sky-avatar [name]="user.name"></sky-avatar>
   {{ user.name }}
@@ -167,25 +167,25 @@ export class AboutUserComponent {
 <p>{{ user.email }}</p>
 
 <p><a routerLink="..">Back to About</a></p>
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
         In the <stache-code>_id</stache-code> subfolder, add <stache-code>index.html</stache-code> to create a page and insert the <stache-code>my-about-user</stache-code> component. The component requires an ID, which we can set with the <stache-code>userId</stache-code> attribute. For this tutorial, let's also include the shared <stache-code>app-nav</stache-code> and a note to highlight how we handle the ID.
       </p>
-      <stache-code-block>
+      <sky-code-block>
 <app-nav></app-nav>
 
 <sky-alert alertType="info">The <code>id</code> parameter is automatically available and can be passed in to our <code>MyAboutUser</code> component.  Using id: {{ id }}.</sky-alert>
 
 <my-about-user [userId]="id"></my-about-user>
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
         In the <stache-code>src/app/about</stache-code> folder, edit <stache-code>about-user.component.html</stache-code> to link from the About page to information about team members. We can remove the avatar element since we included it in <stache-code>about-user.component.html</stache-code>, and we can replace the email address with a <stache-code>routerLink</stache-code> to more information about a user.
       </p>
-      <stache-code-block>
+      <sky-code-block>
 <app-nav></app-nav>
 <h1>About our Team</h1>
 
@@ -207,7 +207,7 @@ export class AboutUserComponent {
     </sky-key-info>
   </div>
 </div>
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>

--- a/src/app/learn/get-started/advanced/route-wildcard/index.html
+++ b/src/app/learn/get-started/advanced/route-wildcard/index.html
@@ -13,22 +13,22 @@
     To customize the wildcard route, you can create a <stache-code>not-found.component.ts</stache-code> file in <stache-code>src/app</stache-code>, import the <stache-code>Component</stache-code> class from Angular to provide functionality to the component, define the template for the component, and export the <stache-code>NotFoundComponent</stache-code> component class:
   </p>
 
-  <stache-code-block languageType="typescript">
+  <sky-code-block languageType="typescript">
 import { Component } from '@angular/core';
 
 @Component({
   templateUrl: './not-found.component.html'
 })
 export class NotFoundComponent {}
-  </stache-code-block>
+  </sky-code-block>
 
   <p>
     You can then create a <stache-code>not-found.component.html</stache-code> file in <stache-code>src/app</stache-code> and provide the content for the wildcard route to display:
   </p>
 
-  <stache-code-block languageType="markup">
+  <sky-code-block languageType="markup">
 This is my custom 404 page.
-  </stache-code-block>
+  </sky-code-block>
 
   <p>
     Please note that while the filename is technically not important to this functionality, the component name is crucial. The component must export <stache-code>NotFoundComponent</stache-code>.

--- a/src/app/learn/get-started/advanced/unit-test-modals/index.html
+++ b/src/app/learn/get-started/advanced/unit-test-modals/index.html
@@ -16,7 +16,7 @@
     <p>
       The first way to unit test components that use the modal service is to create tests that launch modals and interacts with them. This allows you to create tests that ensure data is passed properly to the launched modal and then passed back to the caller of the modal service when the modal is saved. The following code shows the setup necessary for this sort of test:
     </p>
-    <stache-code-block languageType="typescript">
+    <sky-code-block languageType="typescript">
         let applicationRef: ApplicationRef;
 
         beforeEach(() => {
@@ -42,14 +42,14 @@
             }
           )
         );
-    </stache-code-block>
+    </sky-code-block>
     <p>
       The first <stache-code>beforeEach</stache-code> function configures the testing module with our standard <stache-code>SkyAppTestModule</stache-code>. The second <stache-code>beforeEach</stache-code> function injects the <stache-code>SkyModalService</stache-code> and disposes it to ensure that previous test modals are destroyed. It also saves a reference to <stache-code>applicationRef</stache-code>, which must be used to detect changes when interacting with the launched modal because the modal content lives outside of the currently tested component.
     </p>
     <p>
       After this setup, a component that contains logic to launch a modal can be tested with something like the following test:
     </p>
-    <stache-code-block languageType="typescript">
+    <sky-code-block languageType="typescript">
         it('should launch and save data with the modal', fakeAsync(() => {
           const fixture = TestBed.createComponent(ModalLaunchingComponent);
           fixture.detectChanges();
@@ -65,7 +65,7 @@
           applicationRef.tick();
           fixture.detectChanges();
         }));
-    </stache-code-block>
+    </sky-code-block>
     <p>
       In this test example, the <stache-code>ModalLaunchingComponent</stache-code> is created, a button within the component is clicked to launch the modal, and a button within the modal is clicked to save the modal. (In an actual test, you might use <stache-code>expect</stache-code> statements to confirm that certain component properties are set after saving the modal.)
     </p>
@@ -77,7 +77,7 @@
     <p>
       Another way to unit test components that launch modals is to mock the <stache-code>SkyModalService</stache-code>. This is usually the preferred methodology because it allows you to unit test components that launch modals in isolation. The following code shows the setup necessary for this sort of test:
     </p>
-    <stache-code-block languageType="typescript">
+    <sky-code-block languageType="typescript">
       class MockModalService {
         constructor() { };
         public open() {
@@ -109,14 +109,14 @@
           ]
         });
       });
-    </stache-code-block>
+    </sky-code-block>
     <p>
       In this example, we create a class that mocks the necessary modal service functionality. It provides an open function and saves the callback for the modal <stache-code>closed</stache-code> subscription. In the <stache-code>beforeEach</stache-code> function, we configure our testing module and override the <stache-code>SkyModalService</stache-code> provider with an instance of the <stache-code>MockModalService</stache-code> that we define.
     </p>
     <p>
       After this setup, a component that contains logic to launch a modal can be tested by our <stache-code>MockModalService</stache-code> with something like the following test:
     </p>
-    <stache-code-block languageType="typescript">
+    <sky-code-block languageType="typescript">
       it('should mock opening and saving a modal', () => {
 
         const fixture = TestBed.createComponentModalLaunchingComponent);
@@ -136,7 +136,7 @@
 
         fixture.detectChanges();
       });
-    </stache-code-block>
+    </sky-code-block>
     <p>
       In this test example, the <stache-code>ModalLaunchingComponent</stache-code> is created, a button within the component is clicked to launch the modal, and our <stache-code>MockModalService</stache-code> is called to simulate the modal saving. (In an actual test, you might use <stache-code>expect</stache-code> statements to confirm that certain component properties are set after saving the modal.)
     </p>
@@ -148,7 +148,7 @@
     <p>
       You can also test a modal component that launches the modal service in isolation. To do this, you must mock <stache-code>SkyModalInstance</stache-code>, <stache-code>SkyModalHostService</stache-code>, and <stache-code>SkyModalConfiguration</stache-code>. The following code shows the setup necessary for this sort of test:
     </p>
-    <stache-code-block languageType="typescript">
+    <sky-code-block languageType="typescript">
       class MockModalInstance {
         constructor() { };
 
@@ -208,11 +208,11 @@
           ]
         });
       });
-    </stache-code-block>
+    </sky-code-block>
     <p>
       In this example, we create classes that mock the necessary functionality for modal components. After this setup, you can test your modal component in isolation with something like the following test:
     </p>
-    <stache-code-block languageType="typescript">
+    <sky-code-block languageType="typescript">
       it('should create a modal component without having to use the modal service', () => {
         const fixture = TestBed.createComponent(ModalDemoComponent);
         fixture.detectChanges();
@@ -224,7 +224,7 @@
 
         expect(modalInstance.saveResult).toBe('complete');
       });
-    </stache-code-block>
+    </sky-code-block>
     <p>
       In this test example, we create a modal component and test it like any other standalone component. Then we can use our <stache-code>MockModalInstance</stache-code> to verify results of specific actions such as saving the modal.
     </p>

--- a/src/app/learn/get-started/basics/edit-project/index.html
+++ b/src/app/learn/get-started/basics/edit-project/index.html
@@ -10,11 +10,11 @@
     </p>
   </stache-page-summary>
 
-  
+
   <stache-page-anchor>
     Edit an existing page
   </stache-page-anchor>
-  
+
   <ol>
     <li>
       <p>
@@ -25,7 +25,7 @@
       <p>
         In a local editor, open the project's <stache-code>about.component.html</stache-code> file in the <stache-code>src/app/about</stache-code> folder.
       </p>
-      <stache-code-block>
+      <sky-code-block>
         <app-nav></app-nav>
         <h1>About our Team</h1>
 
@@ -48,17 +48,17 @@
             </sky-key-info>
           </div>
         </div>
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
         At the top of the file before the warning, add a paragraph.
       </p>
-      <stache-code-block languageType="markup">
+      <sky-code-block languageType="markup">
         <p>
           This page provides contact information for members of our team.
         </p>
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
@@ -81,11 +81,11 @@
       <p>
         Edit the type and message for the alert component. For example, in the <stache-code>alertType</stache-code> attribute, change the value to from <stache-code>warning</stache-code> to <stache-code>info</stache-code>. And in the <stache-code>sky-alert</stache-code> element, change the message to <stache-code>There may be a delay in responding to your email.</stache-code>
       </p>
-      <stache-code-block languageType="markup">
+      <sky-code-block languageType="markup">
         <sky-alert alertType="info">
           <strong>Note:</strong> There may be a delay in responding to your email.
         </sky-alert>
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
@@ -108,7 +108,7 @@
       <p>
         Between the alert and avatar components, add a card component. Add the <stache-code>sky-card</stache-code> element, and then within that element, add the <stache-code>sky-card-title</stache-code> element for the header text, the <stache-code>sky-card-content</stache-code> element for the body content, and the <stache-code>sky-card-actions</stache-code> element for the button.
       </p>
-      <stache-code-block languageType="markup">
+      <sky-code-block languageType="markup">
         <sky-card>
           <sky-card-title>Large card</sky-card-title>
           <sky-card-content>
@@ -123,7 +123,7 @@
             <button class="sky-btn sky-btn-default">Click me</button>
           </sky-card-actions>
         </sky-card>
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
@@ -154,27 +154,27 @@
       <p>
         In the new file, place the shared <stache-code>app-nav</stache-code> component at the top and then add hello world content such as <stache-code>&#60;h1&#62;Hello world!&#60;&#47;h1&#62;</stache-code>. The <stache-code>app-nav</stache-code> component is an example of a shared component. It manually creates top-level navigation within your app.
       </p>
-      <stache-code-block languageType="markup">
+      <sky-code-block languageType="markup">
         <app-nav></app-nav>
         <h1>Hello World!</h1>
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
         In the <stache-code>src/assets/locales</stache-code> folder, open the <stache-code>resources_en_US.json</stache-code> file and add a localization string for a top-level navigation item to access the Demo page.
       </p>
-      <stache-code-block languageType="typescript">
+      <sky-code-block languageType="typescript">
 "app_nav_demo": {
   "message": "Demo",
   "_description": "The text for the Demo top-level navigation item"
 },
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
         In the <stache-code>src/app/shared</stache-code> folder, open the <stache-code>app-nav.component.ts</stache-code> file and add a path for the Demo page. Set <stache-code>titleKey</stache-code> to the localization string we just added to <stache-code>resources_en_US.json</stache-code>, and set <stache-code>path</stache-code> to "/demo." <stache-code>titleKey</stache-code> specifies a label for the menu, and <stache-code>path</stache-code> specifies the location of the folder.
       </p>
-      <stache-code-block languageType="typescript">
+      <sky-code-block languageType="typescript">
         import { Component } from '@angular/core';
 
         @Component({
@@ -198,7 +198,7 @@
             }
           ];
         }
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
@@ -233,7 +233,7 @@
       <p>
         In your code editor, navigate to the <stache-code>demo</stache-code> folder, and open the <stache-code>my-demo.component.ts</stache-code> file that includes boilerplate code to create your component.
       </p>
-      <stache-code-block languageType="typescript">
+      <sky-code-block languageType="typescript">
         import {
           Component
         } from '@angular/core';
@@ -246,13 +246,13 @@
         export class MyDemoComponent {
 
         }
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
         We want our component to accept input from the host page. This requires a public property with the Angular <stache-code>@Input</stache-code> decorator. We can import this decorator from <stache-code>@angular/core</stache-code>. For this example, we'll add an input property called <stache-code>message</stache-code>.
       </p>
-      <stache-code-block languageType="typescript">
+      <sky-code-block languageType="typescript">
           import {
             Component,
             Input
@@ -267,15 +267,15 @@
             @Input()
             public message: string;
           }
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
         Now that the component accepts input, we can display input in the component's template. Open the <stache-code>my-demo.component.html</stache-code> file, and add the following code to display the message.
       </p>
-      <stache-code-block languageType="markup">
+      <sky-code-block languageType="markup">
         {{ message }}
-      </stache-code-block>
+      </sky-code-block>
       <p>
         The curly braces are the syntax to reference public properties of the component class.
       </p>
@@ -284,9 +284,9 @@
       <p>
         Open the <stache-code>index.html</stache-code> file in the <stache-code>demo</stache-code> folder, and add the new <stache-code>app-my-demo</stache-code> component after the header. Set the value of the <stache-code>message</stache-code> attribute to "Hello!"
       </p>
-      <stache-code-block languageType="markup">
+      <sky-code-block languageType="markup">
         <app-my-demo message="Hello!"></app-my-demo>
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>

--- a/src/app/learn/get-started/basics/navigate-spa/index.html
+++ b/src/app/learn/get-started/basics/navigate-spa/index.html
@@ -17,9 +17,9 @@
   <p>
     The <stache-code>skyAppLink</stache-code> attribute automatically includes the SPA's parameters in the URL. The most common parameters are <stache-code>envid</stache-code> and <stache-code>svcid</stache-code>, but the URL can include any parameters that are provided to the SPA when it loads.
   </p>
-  <stache-code-block>
+  <sky-code-block>
     <a skyAppLink="sample-route">Sample Link 2</a>
-  </stache-code-block>
+  </sky-code-block>
   <p>
     If this SPA has a <stache-code>svcid</stache-code> of "abc" and an <stache-code>envid</stache-code> of "1234," the sample directs users to <stache-code>/sample-spa/sample-route?svcid=abc&envid=1234</stache-code>.
   </p>
@@ -32,13 +32,13 @@
   </stache-page-anchor>
 
   <p>
-    To create links to other SPAs, use the standard HTML <stache-code>a</stache-code> element. If the external SPA URL includes parameters, specify the path to link to with the SKY UX <stache-code>skyAppLink</stache-code> attribute. If not, use the standard HTML <stache-code>href</stache-code> attribute. 
+    To create links to other SPAs, use the standard HTML <stache-code>a</stache-code> element. If the external SPA URL includes parameters, specify the path to link to with the SKY UX <stache-code>skyAppLink</stache-code> attribute. If not, use the standard HTML <stache-code>href</stache-code> attribute.
   </p>
     The <stache-code>skyAppLinkExternal</stache-code> attribute automatically includes the external SPA's parameters in the URL. The most common parameters are <stache-code>envid</stache-code> and <stache-code>svcid</stache-code>, but the URL can include any parameters that are provided to the SPA when it loads.
   </p>
-  <stache-code-block>
+  <sky-code-block>
     <a skyAppLinkExternal="/another-spa/sample-route">Sample Link 4</a>
-  </stache-code-block>
+  </sky-code-block>
   <p>
     If this external SPA has a <stache-code>svcid</stache-code> of "abc" and an <stache-code>envid</stache-code> of "1234," the sample directs users to <stache-code>/another-spa/sample-route?svid=abc&envid=1234</stache-code>.
   </p>

--- a/src/app/learn/reference/component-libraries/index.html
+++ b/src/app/learn/reference/component-libraries/index.html
@@ -21,9 +21,9 @@
   <p>
     To create a SKY UX library, you must first create a SPA for the library and specify a base template with a starter module for front-end libraries. From the SKY UX CLI, run <stache-code>skyux new</stache-code> and use the <stache-code>--template</stache-code> option to specify the <stache-code>library</stache-code> template. This creates a SPA with the library template and places source files in <stache-code>/src/app/public</stache-code>.
   </p>
-  <stache-code-block>
+  <sky-code-block>
     skyux new --template library
-  </stache-code-block>
+  </sky-code-block>
   <p>
     After you specify the library template, follow the usual steps <a routerLink="/learn/get-started/basics/create-project">to set up a local SKY UX application</a>.
   </p>
@@ -47,15 +47,15 @@
       <p>
         The <stache-code>name</stache-code> property in <stache-code>skyuxconfig.json</stache-code> specifies the name of the project when running in SKY UX Host. You must update this property to the name of your library. For more information about configuration options, see the <a routerLink="/learn/reference/configuration">configuration options reference</a>.
       </p>
-      <stache-code-block>
+      <sky-code-block>
         "name": "your-library"
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
         The <stache-code>app-extras.module.ts</stache-code> file in <stache-code>/src/app</stache-code> handles tasks such as registering providers and entry components, and SKY UX Builder automatically imports it into the build process. You must import and export your module in this file.
       </p>
-      <stache-code-block>
+      <sky-code-block>
 import { NgModule } from '@angular/core';
 
 import { YourModule } from './public';
@@ -71,7 +71,7 @@ import { YourModule } from './public';
   declarations: []
 })
 export class AppExtrasModule { }
-      </stache-code-block>
+      </sky-code-block>
     </li>
   </ul>
 
@@ -82,9 +82,9 @@ export class AppExtrasModule { }
   <p>
     After you create your library, you are ready to bundle it into a consumable NPM module that you can publish to an NPM stream such as <a href="https://www.npmjs.com/">npmjs.org</a>. From the SKY UX CLI, run <stache-code>skyux build-public-library</stache-code>.
   </p>
-  <stache-code-block>
+  <sky-code-block>
     skyux build-public-library
-  </stache-code-block>
+  </sky-code-block>
   <p>
     This creates a bundle that is NPM-ready and places it in a <stache-code>/dist</stache-code> directory. It bundles the library's components and services in <stache-code>/src/app/public</stache-code> and ignores all other files, but it does not publish the component library.
   </p>
@@ -107,7 +107,7 @@ export class AppExtrasModule { }
   <p>
     After you publish a front-end library, other SKY UX SPAs can install it. To consume a SKY UX library, import the library into your SPA through <stache-code>/app/src/app-extras.module.ts</stache-code>
   </p>
-  <stache-code-block languageType="typescript">
+  <sky-code-block languageType="typescript">
     import { NgModule } from '@angular/core';
 
     import { LibraryModule } from 'my-component-library';
@@ -121,7 +121,7 @@ export class AppExtrasModule { }
       ]
     })
     export class AppExtrasModule { }
-  </stache-code-block>
+  </sky-code-block>
 
   <stache-page-anchor>
     Provide configuration for the library
@@ -130,7 +130,7 @@ export class AppExtrasModule { }
   <p>
     You can provide configuration for the library through the <stache-code>skyuxconfig.json</stache-code> file in the project's directory. In this file, the <stache-code>appSettings</stache-code> property specifies data that is available for reuse throughout the application, and you can use it to add any properties that are necessary for the library.
   </p>
-  <stache-code-block languageType="json">
+  <sky-code-block languageType="json">
     {
       "appSettings": {
         "myLibrary": {
@@ -139,11 +139,11 @@ export class AppExtrasModule { }
         }
       }
     }
-  </stache-code-block>
+  </sky-code-block>
   <p>
     After you add properties through <stache-code>appSettings</stache-code> for the library, you can access them in your components and services by injecting <stache-code>SkyAppConfig</stache-code> from <stache-code>@skyux/config</stache-code>.
   </p>
-  <stache-code-block languageType="typescript">
+  <sky-code-block languageType="typescript">
     import { SkyAppConfig } from '@skyux/config';
 
     @Component({ ... })
@@ -167,6 +167,6 @@ export class AppExtrasModule { }
         console.log(this.config.foo); // "bar"
       }
     }
-  </stache-code-block>
+  </sky-code-block>
 
 </stache>

--- a/src/app/learn/reference/configuration/additional-config-files/index.html
+++ b/src/app/learn/reference/configuration/additional-config-files/index.html
@@ -3,7 +3,7 @@
   navTitle="Additional files"
   showTableOfContents="true"
   navOrder="1">
-  
+
   <stache-page-summary>
     <p>
       The SKY UX template provides the <stache-code>skyuxconfig.json</stache-code> file to specify configuration settings. In addition, you can create configuration files with the <stache-code>skyuxconfig.[COMMAND].json</stache-code> naming convention to apply configuration settings to specific <a routerLink="/learn/reference/cli-commands">SKY UX CLI commands</a>.
@@ -28,12 +28,12 @@
         <p>
           For example, you can specify a mock server URL to use when you run <stache-code>skyux test</stache-code>.
         </p>
-        <stache-code-block languageType="js">{
+        <sky-code-block languageType="js">{
   "appSettings": {
     "mockServerURL": "https://localhost:9000"
   }
 }
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
@@ -92,7 +92,7 @@
   <p>
     For example, if you use a specific environment ID and service ID for testing, you can specify default <stache-code>svcid</stache-code> and <stache-code>envid</stache-code> values for local development in <stache-code>skyuxconfig.serve.json</stache-code>. This allows you to include the environment ID and service ID for testing when you serve without pasting the values in the URL. In addition, if you use the global nav exclusively and don’t want the local nav alongside it, you can set the <stache-code>routes</stache-code> property to <stache-code>false</stache-code>.
   </p>
-  <stache-code-block>
+  <sky-code-block>
 {
   "routes": false,
   "params": {
@@ -104,12 +104,12 @@
     }
   }
 }
-  </stache-code-block>
+  </sky-code-block>
   <p>
     The following code sample illustrates how you can use SKY UX Builder to track parameters in the URL and expose them through your app using the <stache-code>SkyAppConfig</stache-code> class:
   </p>
 
-  <stache-code-block languageType="typescript">
+  <sky-code-block languageType="typescript">
 import { Component } from '@angular/core';
 import { SkyAppConfig } from '@skyux/config';
 
@@ -123,7 +123,7 @@ export class HomeComponent {
     this.envId = skyAppConfig.params.get('envid');
   }
 }
-  </stache-code-block>
+  </sky-code-block>
   <p>
     For more information about <stache-code>envid</stache-code> and other querystring parameters, see <a routerLink="/learn/reference/configuration">the <stache-code>params</stache-code> configuration property</a>.
   </p>

--- a/src/app/learn/reference/configuration/apply-appsettings/index.html
+++ b/src/app/learn/reference/configuration/apply-appsettings/index.html
@@ -9,7 +9,7 @@
       The <stache-code>appSettings</stache-code> property in <stache-code>skyuxconfig.json</stache-code> enables you to reuse data throughout a SPA. The <stache-code>appSettings</stache-code> property accepts strings, arrays, and any other type of configuration setting that is necessary. Use these instructions to access the <stache-code>appSettings</stache-code> data throughout your application.
     </p>
   </stache-page-summary>
-  
+
   <p>
     If you <a routerLink="/learn/reference/configuration/additional-config-files">create files to apply configuration settings</a> to specific SKY UX CLI commands, you can provide command-specific <stache-code>appSettings</stache-code> data in those configuration files.
   </p>
@@ -17,7 +17,7 @@
   <stache-page-anchor>
     Reference appSettings in an index.html file
   </stache-page-anchor>
-  
+
   <ol>
     <li>
       <p>
@@ -28,9 +28,9 @@
       <p>
         Insert the <stache-code>appSettings</stache-code> property and specify the data to reuse throughout the application. For example:
       </p>
-      <stache-code-block languageType="js">"appSettings": {
+      <sky-code-block languageType="js">"appSettings": {
   "exampleSetting1": "foobar"
-}</stache-code-block>
+}</sky-code-block>
     </li>
     <li>
       <p>
@@ -41,9 +41,9 @@
       <p>
         Pull in the config service and reference the <stache-code>appSetting</stache-code> value to access it in the <stache-code>index.html</stache-code> file. For example:
       </p>
-      <stache-code-block>
+      <sky-code-block>
         {{ config.skyux.appSettings.exampleSetting1 &#125;&#125;
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
@@ -66,11 +66,11 @@
       <p>
         Insert the <stache-code>appSettings</stache-code> property and specify the data to reuse throughout the application. For example:
       </p>
-      <stache-code-block languageType="js">
+      <sky-code-block languageType="js">
 "appSettings": {
   "exampleSetting2": "barfoo"
 }
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
@@ -81,15 +81,15 @@
       <p>
         In the <stache-code>component.ts</stache-code> file for the component or the <stache-code>service.ts</stache-code> file for the service, import <stache-code>SkyAppConfig</stache-code> from <stache-code>@skyux/config</stache-code>:
       </p>
-      <stache-code-block languageType="js">
+      <sky-code-block languageType="js">
         import { SkyAppConfig } from '@skyux/config';
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
         Add <stache-code>SkyAppConfig</stache-code> as a private property in the constructor for the component or service: <stache-code>constructor(private skyAppConfig: SkyAppConfig) &#123;&#125;</stache-code>.
       </p>
-      <stache-code-block languageType="js">
+      <sky-code-block languageType="js">
 import { Component } from '@angular/core';
 import { SkyAppConfig } from '@skyux/config';
 
@@ -103,15 +103,15 @@ export class HomeComponent {
     this.config = skyAppConfig;
   }
 }
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
         In the template file for the component or service, pull in the config service and reference the <stache-code>appSettings</stache-code> value to access it in the <stache-code>.html</stache-code> file. For example:
       </p>
-      <stache-code-block languageType="markup">
+      <sky-code-block languageType="markup">
         &#60;p&#62;Sample text: {{ skyAppConfig.skyux.appSettings.exampleSetting2 &#125;&#125;&#60;/p&#62;
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>

--- a/src/app/learn/reference/configuration/index.html
+++ b/src/app/learn/reference/configuration/index.html
@@ -41,7 +41,7 @@
       <p>
         The following example shows an external with all the configuration options:
       </p>
-      <stache-code-block languageType="js">
+      <sky-code-block languageType="js">
   externals: {
     css: {
         before: [
@@ -75,7 +75,7 @@
         ]
     }
 }
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
@@ -86,13 +86,13 @@
       <p>
         <stache-code>styles</stache-code> — Specifies CSS or SCSS files to bundle with the SPA. This property provides an array of <stache-code>string</stache-code> values that represent relative paths for CSS and SCSS files to include in the bundle. The paths are relative to the SPA's root directory.
       </p>
-      <stache-code-block>
+      <sky-code-block>
         "app": {
           "styles": [
             "src/styles/my-styles.scss"
           ]
         }
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
@@ -147,7 +147,7 @@
     <stache-code>cssPath</stache-code>
   </stache-page-anchor>
   <p>
-    The <stache-code>cssPath</stache-code> configuration option specifies a path to reference CSS styles. This property is specific to the SKY UX docs site and is for internal Blackbaud use only. To bundle CSS or SCSS files with your SPA, use the <stache-code>styles</stache-code> property of <a stacheRouterLink="." fragment="app">the <stache-code>app</stache-code> configuration option</a> instead. 
+    The <stache-code>cssPath</stache-code> configuration option specifies a path to reference CSS styles. This property is specific to the SKY UX docs site and is for internal Blackbaud use only. To bundle CSS or SCSS files with your SPA, use the <stache-code>styles</stache-code> property of <a stacheRouterLink="." fragment="app">the <stache-code>app</stache-code> configuration option</a> instead.
   </p>
 
   <stache-page-anchor>
@@ -269,29 +269,29 @@
         <p>
           Parameters as an array of strings:
         </p>
-        <stache-code-block>
+        <sky-code-block>
         "params": [
           "param1",
           "param2"
         ]
-        </stache-code-block>
+        </sky-code-block>
       </li>
       <li>
         <p>
           Parameters as key-value pairs with boolean values:
         </p>
-        <stache-code-block>
+        <sky-code-block>
         "params": {
           "param3": true,
           "param4": true
         }
-        </stache-code-block>
+        </sky-code-block>
       </li>
       <li>
         <p>
           Parameters as objects with default values:
         </p>
-        <stache-code-block>
+        <sky-code-block>
         "params": {
           "param5": {
             "value": "value1"
@@ -300,7 +300,7 @@
             "value": "value2"
           }
         }
-        </stache-code-block>
+        </sky-code-block>
         <p>
           The <stache-code>value</stache-code> property specifies the default value of the parameter, but the query string or other future sources of parameter values can overwrite it at runtime. When using this format, you can also specify the <stache-code>required</stache-code> and <stache-code>excludeFromRequests</stache-code> parameters.
         </p>
@@ -369,12 +369,12 @@
   <p>
     The <stache-code>redirects</stache-code> configuration option specifies redirects for pages within an application. When a project's folder structure changes, you can specify redirects for the files that move so that existing links continue to work. In the <stache-code>redirects</stache-code> property, you create a comma-separated list where you specify the original paths followed by the redirect paths.
   </p>
-  <stache-code-block>
+  <sky-code-block>
   "redirects": {
     "old-folder-1/old-subfolder-1": "new-folder/new-subfolder-1",
     "old-folder-1/old-subfolder-2": "old-folder-1/old-subfolder-2/new-subfolder-2"
   }
-  </stache-code-block>
+  </sky-code-block>
 
   <stache-page-anchor>
     <stache-code>routes</stache-code>

--- a/src/app/learn/reference/helpers/SkyAuthHttpClientModule/index.html
+++ b/src/app/learn/reference/helpers/SkyAuthHttpClientModule/index.html
@@ -7,27 +7,27 @@
       <stache-code>SkyAuthHttpClientModule</stache-code> enables SKY UX SPAs to use Angular's <stache-code>HttpClient</stache-code> service instead of the deprecated <stache-code>Http</stache-code> service. SKY UX SPAs can use <stache-code>HttpClient</stache-code> directly, but they need to supply the <stache-code>skyAuthHttpOptions()</stache-code> function to HTTP calls to capture Blackbaud URL params such as <stache-code>leid</stache-code> and <stache-code>envid</stache-code>.
     </p>
   </stache-page-summary>
-  
+
   <stache-page-anchor>
     Use <stache-code>SkyAuthHttpClientModule</stache-code> to communicate with backend services
   </stache-page-anchor>
-  
+
   <ol>
     <li>
       <p>
         In a local editor, open the <stache-code>skyuxconfig.json</stache-code> file in the root directory and set <a stacheRouterLink="/learn/reference/configuration" fragment="auth">the <stache-code>auth</stache-code> configuration property</a> to <stache-code>true</stache-code>.
       </p>
-      <stache-code-block languageType="json">
+      <sky-code-block languageType="json">
         {
           "auth": true
         }
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
         Open the <stache-code>app-extras.module.ts</stache-code> file in the <stache-code>src/app</stache-code> directory. Import <stache-code>SkyAuthHttpClientModule</stache-code> from <stache-code>@skyux/http</stache-code> and add it to the Angular module’s <stache-code>exports</stache-code> section.
       </p>
-      <stache-code-block languageType="typescript">
+      <sky-code-block languageType="typescript">
         import {
           SkyAuthHttpClientModule
         } from '@skyux/http';
@@ -38,21 +38,21 @@
           ]
         })
         export class AppExtrasModule { }
-      </stache-code-block>
+      </sky-code-block>
     </li>
     <li>
       <p>
         Use the <stache-code>HttpClient</stache-code> service instead of <stache-code>SkyAuthHttp</stache-code> to communicate between the front-end application and backend services. To make authenticated calls, pass in the result of <stache-code>skyAuthHttpOptions()</stache-code>, which is also defined by <stache-code>@skyux/http</stache-code>, to the <stache-code>HttpClient</stache-code> methods.
       </p>
-      <stache-code-block languageType="typescript">
+      <sky-code-block languageType="typescript">
         import {
           HttpClient
         } from '@angular/common/http';
-        
+
         import {
           skyAuthHttpOptions
         } from '@skyux/http';
-        
+
         @Component({
           selector: 'app-foo',
           templateUrl: './foo.component.html'
@@ -61,16 +61,16 @@
           constructor(
             private http: HttpClient
           ) { }
-          
+
           public ngOnInit(): void {
             // Available options are defined here:
             // https://github.com/blackbaud/skyux-http/blob/master/src/app/public/modules/auth-http-client/auth-options.ts#L20-L29
             const options: any = {};
-            
+
             this.http.get('my/api/endpoint', skyAuthHttpOptions(options));
           }
         }
-      </stache-code-block>
+      </sky-code-block>
     </li>
   </ol>
 
@@ -86,13 +86,13 @@
       <stache-code>headers</stache-code> — <em>(Optional.)</em> Specifies <a href="https://angular.io/api/http/Headers">the <stache-code>Headers</stache-code> instance</a> to attach to <a href="https://angular.io/api/http/Request">the <stache-code>Request</stache-code> instance</a>.
     </li>
     <li>
-      <stache-code>observe</stache-code> — <em>(Optional.)</em> Specifies the return type of the observable. The valid options are <stache-code>body</stache-code>, <stache-code>events</stache-code>, and <stache-code>response</stache-code>. 
+      <stache-code>observe</stache-code> — <em>(Optional.)</em> Specifies the return type of the observable. The valid options are <stache-code>body</stache-code>, <stache-code>events</stache-code>, and <stache-code>response</stache-code>.
     </li>
     <li>
       <stache-code>params</stache-code> — <em>(Optional.)</em> Specifies the search parameters to include in <a href="https://angular.io/api/http/Request">the <stache-code>Request</stache-code> instance</a>.
     </li>
     <li>
-      <stache-code>permissionScope</stache-code> — <em>(Optional.)</em> Specifies permissions for the <stache-code>HttpInterceptor</stache-code> interface to intercept and modify HTTP requests globally. This property accepts <stache-code>string</stache-code> values. 
+      <stache-code>permissionScope</stache-code> — <em>(Optional.)</em> Specifies permissions for the <stache-code>HttpInterceptor</stache-code> interface to intercept and modify HTTP requests globally. This property accepts <stache-code>string</stache-code> values.
     </li>
     <li>
       <stache-code>reportProgress</stache-code> — <em>(Optional.)</em> Indicates whether to enable tracking of progress events. This property accepts <stache-code>boolean</stache-code> values. <em>(Default: false)</em>


### PR DESCRIPTION
Updated the version of Stache that includes the fix to TOC to allow dynamic anchors to display.

Removed the custom TOC from demo component.

Replaced all `stache-code-block` with `sky-code-block`.

Added siteNames to the search results to include results from the 
```
          "skyux",
          "bb-help-docs",
          "skyux-migration-guide"
```
sites.