### PR TITLE
Added values for reason property in skyCloseModalArgs

### DIFF
--- a/src/app/components/modal/index.html
+++ b/src/app/components/modal/index.html
@@ -126,7 +126,7 @@
     <sky-demo-page-property
       propertyName="closed"
     >
-    An event that the modal instance emits when it closes. It emits a <stache-code>SkyCloseModalArgs</stache-code> object with a <stache-code>data</stache-code> property that includes data passed from users on close or save and a <stache-code>reason</stache-code> property that indicates whether the modal was saved or closed without saving. The <stache-code>reason</stache-code> property accepts string values such as <stache-code>cancel</stache-code>, <stache-code>close</stache-code>, and <stache-code>save</stache-code>.
+    An event that the modal instance emits when it closes. It emits a <stache-code>SkyCloseModalArgs</stache-code> object with a <stache-code>data</stache-code> property that includes data passed from users on close or save and a <stache-code>reason</stache-code> property that indicates whether the modal was saved or closed without saving. The <stache-code>reason</stache-code> property accepts any string value. Common examples include <stache-code>cancel</stache-code>, <stache-code>close</stache-code>, and <stache-code>save</stache-code>.
     </sky-demo-page-property>
     <sky-demo-page-property
       propertyName="helpOpened"

--- a/src/app/components/modal/index.html
+++ b/src/app/components/modal/index.html
@@ -126,7 +126,7 @@
     <sky-demo-page-property
       propertyName="closed"
     >
-    An event that the modal instance emits when it closes. It emits a <stache-code>SkyCloseModalArgs</stache-code> object with a <stache-code>data</stache-code> property that includes data passed from users on close or save and a <stache-code>reason</stache-code> property that indicates whether the modal was saved or closed without saving.
+    An event that the modal instance emits when it closes. It emits a <stache-code>SkyCloseModalArgs</stache-code> object with a <stache-code>data</stache-code> property that includes data passed from users on close or save and a <stache-code>reason</stache-code> property that indicates whether the modal was saved or closed without saving. The <stache-code>reason</stache-code> property accepts string values such as <stache-code>cancel</stache-code>, <stache-code>close</stache-code>, and <stache-code>save</stache-code>.
     </sky-demo-page-property>
     <sky-demo-page-property
       propertyName="helpOpened"


### PR DESCRIPTION
Based on the Slack thread, I took away that we just needed to call out the values. Let me know if we need to make a proper section for this.

Addresses https://github.com/blackbaud/skyux2-docs/issues/258