### PR TITLE
Update datepicker API

### DIFF
--- a/src/app/components/datepicker/index.html
+++ b/src/app/components/datepicker/index.html
@@ -12,7 +12,7 @@
     <sky-demo-page-property
       propertyName="skyDatepickerInput"
     >
-      Creates the datepicker input and calendar. Place this attribute on an <stache-code>input</stache-code> element, and wrap the input in a <stache-code>sky-datepicker</stache-code> component. The attribute must be set to the instance of the <stache-code>sky-datepicker</stache-code> component.
+      Creates the datepicker input and calendar. Place this directive on an <stache-code>input</stache-code> element, and wrap the input in a <stache-code>sky-datepicker</stache-code> component.
     </sky-demo-page-property>
     <sky-demo-page-property
       propertyName="dateFormat"


### PR DESCRIPTION
Issue: https://github.com/blackbaud/skyux2-docs/issues/399

As of `@skyux/datetime@3.2.0`, setting `skyDatepickerInput` to a reference of `<sky-datepicker>` is not required (the consumer can simply provide `skyDatepickerInput`):

**Before:**
```
<sky-datepicker #mypicker>
  <input [skyDatepickerInput]="mypicker" />
</sky-datepicker>
```

**After:**
```
<sky-datepicker>
  <input skyDatepickerInput />
</sky-datepicker>
```

The demo is being updated, here: https://github.com/blackbaud/skyux2/pull/2347