### PR TITLE
Fix "SkyAuthClientHttpModule" typo in reference section

### DIFF
--- a/src/app/learn/reference/helpers/index.html
+++ b/src/app/learn/reference/helpers/index.html
@@ -18,7 +18,7 @@
     </li>
     <li>
       <p>
-        <sky-code>import &#123; SkyAuthClientHttpModule &#125; from '@skyux/http';</sky-code>  — Enables SKY UX SPAs to use the <sky-code>HttpClient</sky-code> Angular service instead of the deprecated <sky-code>Http</sky-code> service. Use the <sky-code>skyAuthHttpOptions()</sky-code> function in HTTP calls to capture Blackbaud URL params such as <sky-code>leid</sky-code> and <sky-code>envid</sky-code>. This helper is for internal Blackbaud use only. For Blackbaud developers, the Engineering System website describes how to <a href="https://docs.blackbaud.com/engineering-system-docs/learn/spa/spa-authenticated-calls">use <sky-code>SkyAuthHttpClientModule</sky-code> to make authenticated calls from a SPA to a web service</a>.
+        <sky-code>import &#123; SkyAuthHttpClientModule &#125; from '@skyux/http';</sky-code>  — Enables SKY UX SPAs to use the <sky-code>HttpClient</sky-code> Angular service instead of the deprecated <sky-code>Http</sky-code> service. Use the <sky-code>skyAuthHttpOptions()</sky-code> function in HTTP calls to capture Blackbaud URL params such as <sky-code>leid</sky-code> and <sky-code>envid</sky-code>. This helper is for internal Blackbaud use only. For Blackbaud developers, the Engineering System website describes how to <a href="https://docs.blackbaud.com/engineering-system-docs/learn/spa/spa-authenticated-calls">use <sky-code>SkyAuthHttpClientModule</sky-code> to make authenticated calls from a SPA to a web service</a>.
       </p>
     </li>
   </ul>


### PR DESCRIPTION
Updated the `SkyAuthClientHttpModule` to `SkyAuthHttpClientModule` to reflect the actual module name.