### PR TITLE
[HOLD] Implemented restricted view component throughout the site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -445,6 +445,11 @@
       "resolved": "https://registry.npmjs.org/@blackbaud/skyux-lib-media/-/skyux-lib-media-1.0.0.tgz",
       "integrity": "sha512-4X7xYfThbOw0ewYbpLJ9o5GdVYXyMMys0xHmTD1Xx/IOdpq2K4p9i3kS+xgC96PaYrOHFd0NVuwvL6uPiQIUxA=="
     },
+    "@blackbaud/skyux-lib-restricted-view": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-lib-restricted-view/-/skyux-lib-restricted-view-1.0.0.tgz",
+      "integrity": "sha512-TVXwuFIuDovJnHOBPUNRoMtTp+jqShUNh0L43cD4QjxFE2gZhmCUSFBgTWYGq25cwNRw4L+1xtoLZxpCtS0aMA=="
+    },
     "@blackbaud/skyux-lib-stache": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@blackbaud/skyux-lib-stache/-/skyux-lib-stache-3.1.0.tgz",
@@ -4861,9 +4866,9 @@
       }
     },
     "flatted": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
-      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
     },
     "flush-write-stream": {
@@ -8148,9 +8153,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -10877,9 +10882,9 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -12280,38 +12285,15 @@
       "dev": true
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "unique-filename": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@blackbaud/skyux-lib-clipboard": "1.1.0",
     "@blackbaud/skyux-lib-code-block": "1.2.0",
     "@blackbaud/skyux-lib-media": "1.0.0",
+    "@blackbaud/skyux-lib-restricted-view": "1.0.0",
     "@blackbaud/skyux-lib-stache": "3.1.0",
     "@blackbaud/skyux2-demos": "1.0.0-alpha.5",
     "@skyux/action-bars": "3.0.1",

--- a/src/app/app-sky.module.ts
+++ b/src/app/app-sky.module.ts
@@ -17,6 +17,10 @@ import {
 } from '@blackbaud/skyux-lib-media';
 
 import {
+  SkyRestrictedViewModule
+} from '@blackbaud/skyux-lib-restricted-view';
+
+import {
   SkyAvatarModule
 } from '@skyux/avatar';
 
@@ -210,6 +214,7 @@ import {
     SkyProgressIndicatorModule,
     SkyRadioModule,
     SkyRepeaterModule,
+    SkyRestrictedViewModule,
     SkySearchModule,
     SkySectionedFormModule,
     SkySelectFieldModule,

--- a/src/app/components/grid/index.html
+++ b/src/app/components/grid/index.html
@@ -78,7 +78,7 @@
     >
     Specifies the columns to display in the grid based on the <sky-code>id</sky-code> or <sky-code>field</sky-code> properties of the columns. If no columns are specified, then the grid displays all columns. This property accepts an array of <sky-code>string</sky-code> values.
     </sky-demo-page-property>
-    <sky-demo-page-property
+    <sky-demo-page-property *skyRestrictedView
       propertyName="settingsKey"
       isOptional="true"
     >

--- a/src/app/components/grid/index.html
+++ b/src/app/components/grid/index.html
@@ -78,11 +78,11 @@
     >
     Specifies the columns to display in the grid based on the <sky-code>id</sky-code> or <sky-code>field</sky-code> properties of the columns. If no columns are specified, then the grid displays all columns. This property accepts an array of <sky-code>string</sky-code> values.
     </sky-demo-page-property>
-    <sky-demo-page-property *skyRestrictedView
+    <sky-demo-page-property
       propertyName="settingsKey"
       isOptional="true"
     >
-    Specifies a unique key for the UI Config Service to retrieve stored settings from a database. The UI Config Service saves configuration settings for users and returns <sky-code>selectedColumnIds</sky-code> to preserve their preferred column order and the sorting of columns. This property accepts <sky-code>string</sky-code> values. This property is for internal Blackbaud use only. For Blackbaud developers, the UI Config Service website describes how to <a href="https://docs.blackbaud.com/ui-config-service-docs/learn/integrations/skyux-components/grids">apply sticky settings to grids</a>.
+    Specifies a unique key for the UI Config Service to retrieve stored settings from a database. <sky-restricted-view>The UI Config Service saves configuration settings for users and returns <sky-code>selectedColumnIds</sky-code> to preserve their preferred column order and the sorting of columns. This property accepts <sky-code>string</sky-code> values.</sky-restricted-view> This property is for internal Blackbaud use only. <sky-restricted-view>For Blackbaud developers, the UI Config Service website describes how to <a href="https://docs.blackbaud.com/ui-config-service-docs/learn/integrations/skyux-components/grids">apply sticky settings to grids</a>.</sky-restricted-view>
     </sky-demo-page-property>
     <sky-demo-page-property
       propertyName="sortField"

--- a/src/app/components/help-inline/index.html
+++ b/src/app/components/help-inline/index.html
@@ -10,7 +10,7 @@
       The help inline component creates a small button next to a field. When clicked they can trigger an action that displays more information about that field that the user might need information on.
     </p>
 
-    <p>
+    <p *skyRestrictedView>
       <stache-include fileName="help-widget.html"></stache-include>
     </p>
   </sky-demo-page-summary>

--- a/src/app/components/list/grid/index.html
+++ b/src/app/components/list/grid/index.html
@@ -74,7 +74,7 @@
     >
     Specifies a search function to apply on the view data. This property accepts values of type <sky-code>(data: any, searchText: string) => boolean</sky-code>.
     </sky-demo-page-property>
-    <sky-demo-page-property
+    <sky-demo-page-property *skyRestrictedView
       propertyName="settingsKey"
       isOptional="true"
     >

--- a/src/app/components/list/grid/index.html
+++ b/src/app/components/list/grid/index.html
@@ -74,11 +74,11 @@
     >
     Specifies a search function to apply on the view data. This property accepts values of type <sky-code>(data: any, searchText: string) => boolean</sky-code>.
     </sky-demo-page-property>
-    <sky-demo-page-property *skyRestrictedView
+    <sky-demo-page-property
       propertyName="settingsKey"
       isOptional="true"
     >
-    Specifies a unique key for the UI Config Service to retrieve stored settings from a database. The UI Config Service saves configuration settings for users and returns <sky-code>selectedColumnIds</sky-code> to preserve their preferred column order and the sorting of columns. This property accepts <sky-code>string</sky-code> values. This property is for internal Blackbaud use only. For Blackbaud developers, the UI Config Service website describes how to <a href="https://docs.blackbaud.com/ui-config-service-docs/learn/integrations/skyux-components/grids">apply sticky settings to grids</a>.
+    Specifies a unique key for the UI Config Service to retrieve stored settings from a database. <sky-restricted-view>The UI Config Service saves configuration settings for users and returns <sky-code>selectedColumnIds</sky-code> to preserve their preferred column order and the sorting of columns. This property accepts <sky-code>string</sky-code> values.</sky-restricted-view> This property is for internal Blackbaud use only. <sky-restricted-view>For Blackbaud developers, the UI Config Service website describes how to <a href="https://docs.blackbaud.com/ui-config-service-docs/learn/integrations/skyux-components/grids">apply sticky settings to grids</a>.</sky-restricted-view>
     </sky-demo-page-property>
     <sky-demo-page-property
       propertyName="width"
@@ -90,7 +90,7 @@
 
   <sky-demo-page-properties sectionHeading="List view grid events">
     <p>
-      When the multiselect feature is enabled and the selected checkboxes change, <a stacheRouterLink="components/list/overview">the list component's</a> <sky-code>selectedIdsChange</sky-code> event emits a <sky-code>Map string, boolean</sky-code> object to indicate the selected items. This differs from multiselect behavior in <a stacheRouterLink="components/grid">the grid component</a> where the <sky-code>multiselectSelectionChange</sky-code> event emits an array of IDs for the selected rows when the selection changes. 
+      When the multiselect feature is enabled and the selected checkboxes change, the <sky-code>selectedIdsChange</sky-code> event for <a stacheRouterLink="components/list/overview">the list component</a> emits a <sky-code>Map string, boolean</sky-code> object to indicate the selected items. This differs from multiselect behavior in <a stacheRouterLink="components/grid">the grid component</a> where the <sky-code>multiselectSelectionChange</sky-code> event emits an array of IDs for the selected rows when the selection changes. 
     </p>
     <sky-demo-page-property
       propertyName="selectedColumnIdsChange"

--- a/src/app/components/modal/index.html
+++ b/src/app/components/modal/index.html
@@ -58,7 +58,7 @@
       propertyName="helpKey"
       isOptional="true"
     >
-    Specifies a <sky-code>helpKey</sky-code> string. This property dispays the <i class="fa fa-question-circle" aria-hidden="true"></i> button in the modal header. When users click this button, the <sky-code>helpOpened</sky-code> event broadcasts the <sky-code>helpKey</sky-code> parameter. Blackbaud developers can use the Help Widget, which is for internal Blackbaud use only, to <a href="https://docs.blackbaud.com/bb-help-docs/components/modal-header">display help content in a flyout panel</a>.
+    Specifies a <sky-code>helpKey</sky-code> string. This property dispays the <i class="fa fa-question-circle" aria-hidden="true"></i> button in the modal header. When users click this button, the <sky-code>helpOpened</sky-code> event broadcasts the <sky-code>helpKey</sky-code> parameter. <sky-restricted-view>Blackbaud developers can use the Help Widget, which is for internal Blackbaud use only, to <a href="https://docs.blackbaud.com/bb-help-docs/components/modal-header">display help content in a flyout panel</sky-restricted-view></a>.
     </sky-demo-page-property>
     <sky-demo-page-property
       propertyName="size"

--- a/src/app/components/tile/index.html
+++ b/src/app/components/tile/index.html
@@ -67,7 +67,7 @@
     >
     Populates the tile dashboard based on <a stacheRouterLink="." fragment="skytiledashboardconfig-properties">the <sky-code>SkyTileDashboardConfig</sky-code> object</a>.
     </sky-demo-page-property>
-    <sky-demo-page-property
+    <sky-demo-page-property *skyRestrictedView
       propertyName="settingsKey"
       isOptional="true"
     >

--- a/src/app/components/tile/index.html
+++ b/src/app/components/tile/index.html
@@ -67,11 +67,11 @@
     >
     Populates the tile dashboard based on <a stacheRouterLink="." fragment="skytiledashboardconfig-properties">the <sky-code>SkyTileDashboardConfig</sky-code> object</a>.
     </sky-demo-page-property>
-    <sky-demo-page-property *skyRestrictedView
+    <sky-demo-page-property
       propertyName="settingsKey"
       isOptional="true"
     >
-    Specifies a unique key for the UI Config Service to retrieve stored settings from a database. The UI Config Service saves configuration settings for users to preserve the layout and collapsed state of tile dashboards. This property accepts <sky-code>string</sky-code> values. This property is for internal Blackbaud use only. For Blackbaud developers, the UI Config Service website describes how to <a href="https://docs.blackbaud.com/ui-config-service-docs/learn/integrations/skyux-components/tiles">apply sticky settings to tile dashboards</a>.
+    Specifies a unique key for the UI Config Service to retrieve stored settings from a database. <sky-restricted-view>The UI Config Service saves configuration settings for users to preserve the layout and collapsed state of tile dashboards. This property accepts <sky-code>string</sky-code> values.</sky-restricted-view> This property is for internal Blackbaud use only. <sky-restricted-view>For Blackbaud developers, the UI Config Service website describes how to <a href="https://docs.blackbaud.com/ui-config-service-docs/learn/integrations/skyux-components/tiles">apply sticky settings to tile dashboards</a>.</sky-restricted-view>
     </sky-demo-page-property>
   </sky-demo-page-properties>
 

--- a/src/app/design/guidelines/user-assistance/index.html
+++ b/src/app/design/guidelines/user-assistance/index.html
@@ -48,7 +48,7 @@
 				<li>
 					For an empty container where a call to action does not apply, identify the container with centered, deemphasized text. Do not include other content such as controls or actions.
 				</li>
-				<li>
+				<li *SkyRestrictedView>
 					For Blackbaud designers and developers, we also recommend that you engage a writer on the Strategic Content Development team to help write or review the help content.  
 				</li>
 			</ul>

--- a/src/app/design/guidelines/user-assistance/index.html
+++ b/src/app/design/guidelines/user-assistance/index.html
@@ -191,12 +191,11 @@
 		</sky-column>
 	</sky-row>
 
-	<sky-restricted-view>
-	<stache-page-anchor>
+	<stache-page-anchor *skyRestrictedView>
 		Preloaded Help Widget
 	</stache-page-anchor>
 
-	<sky-row>
+	<sky-row *skyRestrictedView>
 		<sky-column screenSmall="6">
 			<div class="sky-subsection-heading">Usage</div>
 			<p>
@@ -215,6 +214,5 @@
 			</div>
 		</sky-column>
 	</sky-row>
-	</sky-restricted-view>
 
 </stache>

--- a/src/app/design/guidelines/user-assistance/index.html
+++ b/src/app/design/guidelines/user-assistance/index.html
@@ -102,7 +102,7 @@
 						<p>
 							For complex tasks where users require comprehensive documentation for the entire task, they invoke help at the page or modal level depending on the context.
 						</p>
-						<p>
+						<p *skyRestrictedView>
 							In Blackbaud products, users can invoke the help service from the omnibar or a <a routerLink="/components/modal">modal</a> header bar. <stache-include fileName="help-widget.html"></stache-include>
 						</p>
 						</sky-repeater-item-content>
@@ -191,6 +191,7 @@
 		</sky-column>
 	</sky-row>
 
+	<sky-restricted-view>
 	<stache-page-anchor>
 		Preloaded Help Widget
 	</stache-page-anchor>
@@ -214,5 +215,6 @@
 			</div>
 		</sky-column>
 	</sky-row>
+	</sky-restricted-view>
 
 </stache>

--- a/src/app/learn/get-started/advanced/sticky-settings/index.html
+++ b/src/app/learn/get-started/advanced/sticky-settings/index.html
@@ -9,7 +9,7 @@
     </p>
   </stache-page-summary>
 
-  <sky-alert>
+  <sky-alert *skyRestrictedView>
     For Blackbaud developers, the sticky settings functionality is available first-class through the UI Config Service. This service is for internal Blackbaud use only. Blackbaud developers can learn more about how to implement sticky settings on <a href="https://docs.blackbaud.com/ui-config-service-docs/">the UI Config Service website</a>.
   </sky-alert>
   <p>

--- a/src/app/learn/get-started/basics/build-publish/index.html
+++ b/src/app/learn/get-started/basics/build-publish/index.html
@@ -7,7 +7,7 @@
     <p>
       Before you build and publish your SPA, you must first choose a web server to host your site. We recommend <a href="https://pages.github.com/">GitHub Pages</a>, a free tool suitable for front-end projects.
     </p>
-    <sky-alert alertType="info">
+    <sky-alert alertType="info" *skyRestrictedView>
       Blackbaud developers should create repos and provision applications through the SKY UX App Management Portal. Documentation on the SKY UX App Management Portal is available on <a href="https://host.nxt.blackbaud.com/engineering-system-docs/learn/spa/spa-app-portal">the Engineering System website</a>. This site is for Blackbaud internal use only and is not available to external developers.
     </sky-alert>
   </stache-page-summary>

--- a/src/app/learn/get-started/basics/create-project/index.html
+++ b/src/app/learn/get-started/basics/create-project/index.html
@@ -7,7 +7,7 @@
     <p>
       After you <a stacheRouterLink="/learn/get-started/prereqs">install SKY UX prerequisites</a>, you can use the SKY UX CLI to create a local single-page application. We recommend that you set up a Git repo for its source files so that the CLI can clone the repo and automatically pull in the SKY UX template. However, to work locally only, you can create the SPA without a repo.
     </p>
-    <p>
+    <p *skyRestrictedView>
       Blackbaud developers should create repos and provision applications through the SKY UX App Management Portal. Documentation on the SKY UX App Management Portal is available on <a href="https://host.nxt.blackbaud.com/engineering-system-docs/learn/spa/spa-app-portal">the Engineering System website</a>. This site is for Blackbaud internal use only and is not available to external developers.
     </p>
   </stache-page-summary>

--- a/src/app/learn/get-started/basics/create-project/index.html
+++ b/src/app/learn/get-started/basics/create-project/index.html
@@ -7,9 +7,9 @@
     <p>
       After you <a stacheRouterLink="/learn/get-started/prereqs">install SKY UX prerequisites</a>, you can use the SKY UX CLI to create a local single-page application. We recommend that you set up a Git repo for its source files so that the CLI can clone the repo and automatically pull in the SKY UX template. However, to work locally only, you can create the SPA without a repo.
     </p>
-    <p *skyRestrictedView>
+    <sky-alert alertType="info" *SkyRestrictedView>
       Blackbaud developers should create repos and provision applications through the SKY UX App Management Portal. Documentation on the SKY UX App Management Portal is available on <a href="https://host.nxt.blackbaud.com/engineering-system-docs/learn/spa/spa-app-portal">the Engineering System website</a>. This site is for Blackbaud internal use only and is not available to external developers.
-    </p>
+    </sky-alert>
   </stache-page-summary>
 
   <ol>

--- a/src/app/learn/reference/component-libraries/index.html
+++ b/src/app/learn/reference/component-libraries/index.html
@@ -10,7 +10,7 @@
     </p>
   </stache-page-summary>
 
-  <sky-alert alertType="info">
+  <sky-alert alertType="info" *skyRestrictedView>
     Blackbaud developers must follow a different workflow to create internal Blackbaud libraries and publish them to an internal NPM stream. Documentation on this process is available on <a href="https://host.nxt.blackbaud.com/engineering-system-docs/learn/spa/spa-component-libraries">the Engineering System website</a>. This site is for Blackbaud internal use only and is not available to external developers.
   </sky-alert>
 
@@ -104,7 +104,7 @@ export class AppExtrasModule { }
   <p>
     After you bundle the library into a consumable NPM module, you can publish it to an NPM stream to allow other SKY UX SPAs to install the library. We recommend that you publish public libraries to <a href="https://www.npmjs.com/">npmjs.org</a>. You can use Travis-CI, a free GitHub continuous integration service, to publish the component library to npmjs.org.
   </p>
-  <sky-alert alertType="info">
+  <sky-alert alertType="info" *skyRestrictedView>
     Blackbaud developers publish private libraries to an internal Blackbaud NPM stream using a process that is documented on <a href="https://host.nxt.blackbaud.com/engineering-system-docs/learn/spa/spa-component-libraries">the Engineering System website</a>. This site is for Blackbaud internal use only and is not available to external developers.
   </sky-alert>
 

--- a/src/app/learn/reference/configuration/index.html
+++ b/src/app/learn/reference/configuration/index.html
@@ -108,11 +108,11 @@
     The <sky-code>appSettings</sky-code> configuration option specifies data that is available for reuse throughout the application. The data type of this property is <sky-code>any</sky-code>. After you specify data in the <sky-code>appSettings</sky-code> property, you can <a routerLink="/learn/reference/configuration/apply-appsettings">access that data throughout the SPA</a>.
   </p>
 
-  <stache-page-anchor *skyRestrictedview>
+  <stache-page-anchor>
     <sky-code>auth</sky-code>
   </stache-page-anchor>
   <p>
-    The <sky-code>auth</sky-code> configuration option indicates whether the application requires an authenticated Blackbaud ID. This property is for internal Blackbaud use only. By default, this property is set to <sky-code>false</sky-code>. To require authentication, set this property to <sky-code>true</sky-code>. For Blackbaud developers, <a routerLink="/learn/reference/helpers">the helpers reference</a> provides information about how to make authenticated HTTP requests.
+    The <sky-code>auth</sky-code> configuration option indicates whether the application requires an authenticated Blackbaud ID. This property is for internal Blackbaud use only. <sky-restricted-view>By default, this property is set to <sky-code>false</sky-code>. To require authentication, set this property to <sky-code>true</sky-code>. For Blackbaud developers, <a routerLink="/learn/reference/helpers">the helpers reference</a> provides information about how to make authenticated HTTP requests.</sky-restricted-view>
   </p>
 
   <stache-page-anchor>
@@ -150,11 +150,11 @@
     The <sky-code>cssPath</sky-code> configuration option specifies a path to reference CSS styles. This property is specific to the SKY UX docs site and is for internal Blackbaud use only. To bundle CSS or SCSS files with your SPA, use the <sky-code>styles</sky-code> property of <a stacheRouterLink="." fragment="app">the <sky-code>app</sky-code> configuration option</a> instead.
   </p>
 
-  <stache-page-anchor *skyRestrictedView>
+  <stache-page-anchor>
     <sky-code>help</sky-code>
   </stache-page-anchor>
   <p>
-    The <sky-code>help</sky-code> configuration option indicates whether to automatically include the Help Widget in the application to identify the current page and display relevant help content. This property is for internal Blackbaud use only. By default, this property is set to <sky-code>false</sky-code>. For Blackbaud developers who want to include the Help Widget, <a href="https://docs.blackbaud.com/bb-help-docs/learn/configuration/recommended">the Help Widget configuration options documentation</a> describes the configuration object to set the <sky-code>help</sky-code> property to.
+    The <sky-code>help</sky-code> configuration option indicates whether to automatically include the Help Widget in the application to identify the current page and display relevant help content. This property is for internal Blackbaud use only. <sky-restricted-view>By default, this property is set to <sky-code>false</sky-code>. For Blackbaud developers who want to include the Help Widget, <a href="https://docs.blackbaud.com/bb-help-docs/learn/configuration/recommended">the Help Widget configuration options documentation</a> describes the configuration object to set the <sky-code>help</sky-code> property to.</sky-restricted-view>
   </p>
 
   <stache-page-anchor>
@@ -199,11 +199,11 @@
     The <sky-code>name</sky-code> configuration option specifies the name of the project when running in SKY UX Host. For example, if you specify "demo" as the name, then your SPA is accessible from https://host.nxt.blackbaud.com/demo. By default, SKY UX Builder uses the <sky-code>name</sky-code> property in the <sky-code>package.json</sky-code> file, minus the "blackbaud-skyux-spa-" prefix. That value is based on the root directory name that you specify when you <a routerLink="/learn/get-started/basic/create-project">create a SKY UX project</a>. You can use the <sky-code>name</sky-code> property in <sky-code>skyuxconfig.json</sky-code> to overwrite the default name if you do not want the root directory name in your public-facing URL. For example, if you publish the SPA to NPM, you use the <sky-code>name</sky-code> property in <sky-code>package.json</sky-code>, so you may want to use a different name for the project in SKY UX Host.
   </p>
 
-  <stache-page-anchor *skyRestrictedView>
+  <stache-page-anchor>
     <sky-code>omnibar</sky-code>
   </stache-page-anchor>
   <p>
-    The <sky-code>omnibar</sky-code> configuration option specifies an object to pass to the omnibar's <sky-code>load</sky-code> method. This property is for internal Blackbaud use only. The omnibar provides a common UI element for Blackbaud applications that allows users to navigate between applications. For Blackbaud developers, <a href="https://docs.blackbaud.com/omnibar-docs/learn/configuring">the omnibar configuration options documentation</a> describes the available options to pass to the omnibar.
+    The <sky-code>omnibar</sky-code> configuration option specifies an object to pass to the omnibar's <sky-code>load</sky-code> method. This property is for internal Blackbaud use only. <sky-restricted-view>The omnibar provides a common UI element for Blackbaud applications that allows users to navigate between applications. For Blackbaud developers, <a href="https://docs.blackbaud.com/omnibar-docs/learn/configuring">the omnibar configuration options documentation</a> describes the available options to pass to the omnibar.</sky-restricted-view>
   </p>
 
   <stache-page-anchor>
@@ -376,11 +376,11 @@
   }
   </sky-code-block>
 
-  <stache-page-anchor *skyRestrictedView>
+  <stache-page-anchor>
     <sky-code>routes</sky-code>
   </stache-page-anchor>
   <p>
-    The <sky-code>routes</sky-code> configuration option allows you to use the omnibar but still define navigation items. This property is for internal Blackbaud use only. For Blackbaud developers, the Engineering System website describes how to <a href="https://host.nxt.blackbaud.com/engineering-system-docs/learn/spa/spa-global-navigation">add your SPA to global navigation</a>.
+    The <sky-code>routes</sky-code> configuration option allows you to use the omnibar but still define navigation items. This property is for internal Blackbaud use only. <sky-restricted-view>For Blackbaud developers, the Engineering System website describes how to <a href="https://host.nxt.blackbaud.com/engineering-system-docs/learn/spa/spa-global-navigation">add your SPA to global navigation</a>.</sky-restricted-view>
   </p>
 
   <stache-page-anchor>

--- a/src/app/learn/reference/configuration/index.html
+++ b/src/app/learn/reference/configuration/index.html
@@ -35,7 +35,7 @@
       <p>
         <sky-code>externals</sky-code> — Dynamically injects CSS and JavaScript files into SKY UX Host for the <sky-code>skyux serve</sky-code> or <sky-code>skyux build</sky-code> commands. You should have a specific use-case for an external. For example, Office Addins require their library to load through CDN in the head. The <sky-code>before</sky-code> and <sky-code>after</sky-code> sections of an external indicate whether to include the external resource before or after the default SKY UX Builder resources. The <sky-code>head</sky-code> property, which only applies to JS resources, indicates whether to inject elements within the HTML <sky-code>head</sky-code> element or just before the closing <sky-code>body</sky-code> tag.
       </p>
-      <p>
+      <p *skyRestrictedView>
         For Blackbaud-hosted SPAs, Blackbaud developers must whitelist all URLs in the <sky-code>externals</sky-code> property. If <sky-code>skyuxconfig.json</sky-code> includes externals that are not whitelisted, then the SPA won’t load. To whitelist externals, contact the SKY UX team.
       </p>
       <p>
@@ -108,7 +108,7 @@
     The <sky-code>appSettings</sky-code> configuration option specifies data that is available for reuse throughout the application. The data type of this property is <sky-code>any</sky-code>. After you specify data in the <sky-code>appSettings</sky-code> property, you can <a routerLink="/learn/reference/configuration/apply-appsettings">access that data throughout the SPA</a>.
   </p>
 
-  <stache-page-anchor>
+  <stache-page-anchor *skyRestrictedview>
     <sky-code>auth</sky-code>
   </stache-page-anchor>
   <p>
@@ -150,7 +150,7 @@
     The <sky-code>cssPath</sky-code> configuration option specifies a path to reference CSS styles. This property is specific to the SKY UX docs site and is for internal Blackbaud use only. To bundle CSS or SCSS files with your SPA, use the <sky-code>styles</sky-code> property of <a stacheRouterLink="." fragment="app">the <sky-code>app</sky-code> configuration option</a> instead.
   </p>
 
-  <stache-page-anchor>
+  <stache-page-anchor *skyRestrictedView>
     <sky-code>help</sky-code>
   </stache-page-anchor>
   <p>
@@ -199,7 +199,7 @@
     The <sky-code>name</sky-code> configuration option specifies the name of the project when running in SKY UX Host. For example, if you specify "demo" as the name, then your SPA is accessible from https://host.nxt.blackbaud.com/demo. By default, SKY UX Builder uses the <sky-code>name</sky-code> property in the <sky-code>package.json</sky-code> file, minus the "blackbaud-skyux-spa-" prefix. That value is based on the root directory name that you specify when you <a routerLink="/learn/get-started/basic/create-project">create a SKY UX project</a>. You can use the <sky-code>name</sky-code> property in <sky-code>skyuxconfig.json</sky-code> to overwrite the default name if you do not want the root directory name in your public-facing URL. For example, if you publish the SPA to NPM, you use the <sky-code>name</sky-code> property in <sky-code>package.json</sky-code>, so you may want to use a different name for the project in SKY UX Host.
   </p>
 
-  <stache-page-anchor>
+  <stache-page-anchor *skyRestrictedView>
     <sky-code>omnibar</sky-code>
   </stache-page-anchor>
   <p>
@@ -215,12 +215,12 @@
     <ul>
       <li>
         <p>
-          <sky-code>consumer</sky-code> — Specifies the consumer that calls the provider's API. This is a string value that the developer uses to represent the consumer in the consumer-provider relationship. Blackbaud developers register their consumer with the pact broker at <a href="https://host.nxt.blackbaud.com/pact/">https://host.nxt.blackbaud.com/pact/</a>. This internal Blackbaud-only site is not available to external developers.
+          <sky-code>consumer</sky-code> — Specifies the consumer that calls the provider's API. This is a string value that the developer uses to represent the consumer in the consumer-provider relationship. <sky-restricted-view>Blackbaud developers register their consumer with the pact broker at <a href="https://host.nxt.blackbaud.com/pact/">https://host.nxt.blackbaud.com/pact/</a>. This internal Blackbaud-only site is not available to external developers.</sky-restricted-view>
         </p>
       </li>
       <li>
         <p>
-          <sky-code>dir</sky-code> — Specifies a directory for the pact file that the pact server generates when <sky-code>skyux pact</sky-code> runs. By default, the pact server stores the JSON file in the <sky-code>app/pacts</sky-code> directory. The file includes an array of request/response pairs called interactions to describe the behaviors that the consumer expects from the provider service. The file name follows the format of <sky-code>&#123;consumer}-&#123;provider}.json</sky-code>, where <sky-code>&#123;consumer}</sky-code> is the name of the consumer and <sky-code>&#123;provider}</sky-code> is the name of the provider. The pact file needs to be uploaded to the pact broker. Blackbaud developers can find information on registered services at <a href="https://host.nxt.blackbaud.com/pact/">https://host.nxt.blackbaud.com/pact/</a>. This internal Blackbaud-only site is not available to external developers.
+          <sky-code>dir</sky-code> — Specifies a directory for the pact file that the pact server generates when <sky-code>skyux pact</sky-code> runs. By default, the pact server stores the JSON file in the <sky-code>app/pacts</sky-code> directory. The file includes an array of request/response pairs called interactions to describe the behaviors that the consumer expects from the provider service. The file name follows the format of <sky-code>&#123;consumer}-&#123;provider}.json</sky-code>, where <sky-code>&#123;consumer}</sky-code> is the name of the consumer and <sky-code>&#123;provider}</sky-code> is the name of the provider. The pact file needs to be uploaded to the pact broker. <sky-restricted-view>Blackbaud developers can find information on registered services at <a href="https://host.nxt.blackbaud.com/pact/">https://host.nxt.blackbaud.com/pact/</a>. This internal Blackbaud-only site is not available to external developers.</sky-restricted-view>
         </p>
       </li>
       <li>
@@ -245,7 +245,7 @@
       </li>
       <li>
         <p>
-          <sky-code>provider</sky-code> — Specifies the provider of a service that exposes an API to the consumer. This is a string value that the developer uses to represent the provider in the consumer-provider relationship. Blackbaud developers register the provider with the pact broker at <a href="https://host.nxt.blackbaud.com/pact/">https://host.nxt.blackbaud.com/pact/</a>. This internal Blackbaud-only site is not available to external developers.
+          <sky-code>provider</sky-code> — Specifies the provider of a service that exposes an API to the consumer. This is a string value that the developer uses to represent the provider in the consumer-provider relationship. <sky-restricted-view>Blackbaud developers register the provider with the pact broker at <a href="https://host.nxt.blackbaud.com/pact/">https://host.nxt.blackbaud.com/pact/</a>. This internal Blackbaud-only site is not available to external developers.</sky-restricted-view>
         </p>
       </li>
       <li>
@@ -376,7 +376,7 @@
   }
   </sky-code-block>
 
-  <stache-page-anchor>
+  <stache-page-anchor *skyRestrictedView>
     <sky-code>routes</sky-code>
   </stache-page-anchor>
   <p>
@@ -402,7 +402,7 @@
         </li>
         <li>
           <p>
-            <sky-code>browserSet</sky-code> — Specifies the set of browsers to use during continuous integration e2e testing. For Blackbaud developers, <a href="https://host.nxt.blackbaud.com/browserstack/learn/automated">the Browserstack documentation</a> describes the available values.
+            <sky-code>browserSet</sky-code> — Specifies the set of browsers to use during continuous integration e2e testing. <sky-restricted-view>For Blackbaud developers, <a href="https://host.nxt.blackbaud.com/browserstack/learn/automated">the Browserstack documentation</a> describes the available values.</sky-restricted-view>
           </p>
         </li>
         <li>
@@ -429,7 +429,7 @@
       <ul>
         <li>
           <p>
-            <sky-code>browserSet</sky-code> — Specifies the set of browsers to use during continuous integration unit testing. For Blackbaud developers, <a href="https://host.nxt.blackbaud.com/browserstack/learn/automated">the Browserstack documentation</a> describes the available values.
+            <sky-code>browserSet</sky-code> — Specifies the set of browsers to use during continuous integration unit testing. <sky-restricted-view>For Blackbaud developers, <a href="https://host.nxt.blackbaud.com/browserstack/learn/automated">the Browserstack documentation</a> describes the available values.</sky-restricted-view>
           </p>
         </li>
       </ul>

--- a/src/app/learn/reference/helpers/index.html
+++ b/src/app/learn/reference/helpers/index.html
@@ -16,7 +16,7 @@
         <sky-code>import &#123; SkyHostBrowser &#125; from '@skyux-sdk/e2e</sky-code> — Particularly useful when running <a routerLink="/learn/reference/cli-commands">the <sky-code>skyux e2e</sky-code> command in the SKY UX CLI</a>. Use <sky-code>SkyHostBrowser.get()</sky-code> to automatically add the SKY UX Host base URL, as well as the necessary configuration object to enable local development mode. For example, <sky-code>SkyHostBrowser.get(/my-page?my-qs=1');</sky-code>.
       </p>
     </li>
-    <li>
+    <li *skyRestrictedView>
       <p>
         <sky-code>import &#123; SkyAuthHttpClientModule &#125; from '@skyux/http';</sky-code>  — Enables SKY UX SPAs to use the <sky-code>HttpClient</sky-code> Angular service instead of the deprecated <sky-code>Http</sky-code> service. Use the <sky-code>skyAuthHttpOptions()</sky-code> function in HTTP calls to capture Blackbaud URL params such as <sky-code>leid</sky-code> and <sky-code>envid</sky-code>. This helper is for internal Blackbaud use only. For Blackbaud developers, the Engineering System website describes how to <a href="https://docs.blackbaud.com/engineering-system-docs/learn/spa/spa-authenticated-calls">use <sky-code>SkyAuthHttpClientModule</sky-code> to make authenticated calls from a SPA to a web service</a>.
       </p>


### PR DESCRIPTION
Addresses https://github.com/blackbaud/skyux2-docs/issues/458

Also, Design > Guidelines > User Assistance shows Preloaded Help Widget in the TOC, but the content itself is hidden. I believe this is getting resolved by Samus