### PR TITLE
updated module export location

### DIFF
--- a/src/app/components/list/paging/index.html
+++ b/src/app/components/list/paging/index.html
@@ -2,7 +2,7 @@
   pageTitle="List Paging"
   navTitle="List paging"
   skyuxModule="SkyListPagingModule"
-  packageName="@skyux/lists"
+  packageName="@skyux/list-builder"
 >
 
   <sky-demo-page-summary>


### PR DESCRIPTION
Module actually lives in `skyux-list-builder` not `skyux-lists`.
https://github.com/blackbaud/skyux-list-builder/blob/master/src/app/public/modules/list-paging/list-paging.module.ts