### PR TITLE
Tweak restricted view updates

### DIFF
--- a/src/app/components/grid/index.html
+++ b/src/app/components/grid/index.html
@@ -78,11 +78,11 @@
     >
     Specifies the columns to display in the grid based on the <sky-code>id</sky-code> or <sky-code>field</sky-code> properties of the columns. If no columns are specified, then the grid displays all columns. This property accepts an array of <sky-code>string</sky-code> values.
     </sky-demo-page-property>
-    <sky-demo-page-property *skyRestrictedView
+    <sky-demo-page-property
       propertyName="settingsKey"
       isOptional="true"
     >
-    Specifies a unique key for the UI Config Service to retrieve stored settings from a database. The UI Config Service saves configuration settings for users and returns <sky-code>selectedColumnIds</sky-code> to preserve their preferred column order and the sorting of columns. This property accepts <sky-code>string</sky-code> values. This property is for internal Blackbaud use only. For Blackbaud developers, the UI Config Service website describes how to <a href="https://docs.blackbaud.com/ui-config-service-docs/learn/integrations/skyux-components/grids">apply sticky settings to grids</a>.
+    Specifies a unique key for the UI Config Service to retrieve stored settings from a database. <sky-restricted-view>The UI Config Service saves configuration settings for users and returns <sky-code>selectedColumnIds</sky-code> to preserve their preferred column order and the sorting of columns. This property accepts <sky-code>string</sky-code> values.</sky-restricted-view> This property is for internal Blackbaud use only. <sky-restricted-view>For Blackbaud developers, the UI Config Service website describes how to <a href="https://docs.blackbaud.com/ui-config-service-docs/learn/integrations/skyux-components/grids">apply sticky settings to grids</a>.</sky-restricted-view>
     </sky-demo-page-property>
     <sky-demo-page-property
       propertyName="sortField"

--- a/src/app/components/list/grid/index.html
+++ b/src/app/components/list/grid/index.html
@@ -74,11 +74,11 @@
     >
     Specifies a search function to apply on the view data. This property accepts values of type <sky-code>(data: any, searchText: string) => boolean</sky-code>.
     </sky-demo-page-property>
-    <sky-demo-page-property *skyRestrictedView
+    <sky-demo-page-property
       propertyName="settingsKey"
       isOptional="true"
     >
-    Specifies a unique key for the UI Config Service to retrieve stored settings from a database. The UI Config Service saves configuration settings for users and returns <sky-code>selectedColumnIds</sky-code> to preserve their preferred column order and the sorting of columns. This property accepts <sky-code>string</sky-code> values. This property is for internal Blackbaud use only. For Blackbaud developers, the UI Config Service website describes how to <a href="https://docs.blackbaud.com/ui-config-service-docs/learn/integrations/skyux-components/grids">apply sticky settings to grids</a>.
+    Specifies a unique key for the UI Config Service to retrieve stored settings from a database. <sky-restricted-view>The UI Config Service saves configuration settings for users and returns <sky-code>selectedColumnIds</sky-code> to preserve their preferred column order and the sorting of columns. This property accepts <sky-code>string</sky-code> values.</sky-restricted-view> This property is for internal Blackbaud use only. <sky-restricted-view>For Blackbaud developers, the UI Config Service website describes how to <a href="https://docs.blackbaud.com/ui-config-service-docs/learn/integrations/skyux-components/grids">apply sticky settings to grids</a>.</sky-restricted-view>
     </sky-demo-page-property>
     <sky-demo-page-property
       propertyName="width"
@@ -90,7 +90,7 @@
 
   <sky-demo-page-properties sectionHeading="List view grid events">
     <p>
-      When the multiselect feature is enabled and the selected checkboxes change, <a stacheRouterLink="components/list/overview">the list component's</a> <sky-code>selectedIdsChange</sky-code> event emits a <sky-code>Map string, boolean</sky-code> object to indicate the selected items. This differs from multiselect behavior in <a stacheRouterLink="components/grid">the grid component</a> where the <sky-code>multiselectSelectionChange</sky-code> event emits an array of IDs for the selected rows when the selection changes. 
+      When the multiselect feature is enabled and the selected checkboxes change, the <sky-code>selectedIdsChange</sky-code> event for <a stacheRouterLink="components/list/overview">the list component</a> emits a <sky-code>Map string, boolean</sky-code> object to indicate the selected items. This differs from multiselect behavior in <a stacheRouterLink="components/grid">the grid component</a> where the <sky-code>multiselectSelectionChange</sky-code> event emits an array of IDs for the selected rows when the selection changes. 
     </p>
     <sky-demo-page-property
       propertyName="selectedColumnIdsChange"

--- a/src/app/components/tile/index.html
+++ b/src/app/components/tile/index.html
@@ -67,11 +67,11 @@
     >
     Populates the tile dashboard based on <a stacheRouterLink="." fragment="skytiledashboardconfig-properties">the <sky-code>SkyTileDashboardConfig</sky-code> object</a>.
     </sky-demo-page-property>
-    <sky-demo-page-property *skyRestrictedView
+    <sky-demo-page-property
       propertyName="settingsKey"
       isOptional="true"
     >
-    Specifies a unique key for the UI Config Service to retrieve stored settings from a database. The UI Config Service saves configuration settings for users to preserve the layout and collapsed state of tile dashboards. This property accepts <sky-code>string</sky-code> values. This property is for internal Blackbaud use only. For Blackbaud developers, the UI Config Service website describes how to <a href="https://docs.blackbaud.com/ui-config-service-docs/learn/integrations/skyux-components/tiles">apply sticky settings to tile dashboards</a>.
+    Specifies a unique key for the UI Config Service to retrieve stored settings from a database. <sky-restricted-view>The UI Config Service saves configuration settings for users to preserve the layout and collapsed state of tile dashboards. This property accepts <sky-code>string</sky-code> values.</sky-restricted-view> This property is for internal Blackbaud use only. <sky-restricted-view>For Blackbaud developers, the UI Config Service website describes how to <a href="https://docs.blackbaud.com/ui-config-service-docs/learn/integrations/skyux-components/tiles">apply sticky settings to tile dashboards</a>.</sky-restricted-view>
     </sky-demo-page-property>
   </sky-demo-page-properties>
 

--- a/src/app/design/guidelines/user-assistance/index.html
+++ b/src/app/design/guidelines/user-assistance/index.html
@@ -48,7 +48,7 @@
 				<li>
 					For an empty container where a call to action does not apply, identify the container with centered, deemphasized text. Do not include other content such as controls or actions.
 				</li>
-				<li>
+				<li *SkyRestrictedView>
 					For Blackbaud designers and developers, we also recommend that you engage a writer on the Strategic Content Development team to help write or review the help content.  
 				</li>
 			</ul>

--- a/src/app/learn/get-started/basics/create-project/index.html
+++ b/src/app/learn/get-started/basics/create-project/index.html
@@ -7,9 +7,9 @@
     <p>
       After you <a stacheRouterLink="/learn/get-started/prereqs">install SKY UX prerequisites</a>, you can use the SKY UX CLI to create a local single-page application. We recommend that you set up a Git repo for its source files so that the CLI can clone the repo and automatically pull in the SKY UX template. However, to work locally only, you can create the SPA without a repo.
     </p>
-    <p *skyRestrictedView>
+    <sky-alert alertType="info" *SkyRestrictedView>
       Blackbaud developers should create repos and provision applications through the SKY UX App Management Portal. Documentation on the SKY UX App Management Portal is available on <a href="https://host.nxt.blackbaud.com/engineering-system-docs/learn/spa/spa-app-portal">the Engineering System website</a>. This site is for Blackbaud internal use only and is not available to external developers.
-    </p>
+    </sky-alert>
   </stache-page-summary>
 
   <ol>

--- a/src/app/learn/reference/configuration/index.html
+++ b/src/app/learn/reference/configuration/index.html
@@ -108,11 +108,11 @@
     The <sky-code>appSettings</sky-code> configuration option specifies data that is available for reuse throughout the application. The data type of this property is <sky-code>any</sky-code>. After you specify data in the <sky-code>appSettings</sky-code> property, you can <a routerLink="/learn/reference/configuration/apply-appsettings">access that data throughout the SPA</a>.
   </p>
 
-  <stache-page-anchor *skyRestrictedview>
+  <stache-page-anchor>
     <sky-code>auth</sky-code>
   </stache-page-anchor>
   <p>
-    The <sky-code>auth</sky-code> configuration option indicates whether the application requires an authenticated Blackbaud ID. This property is for internal Blackbaud use only. By default, this property is set to <sky-code>false</sky-code>. To require authentication, set this property to <sky-code>true</sky-code>. For Blackbaud developers, <a routerLink="/learn/reference/helpers">the helpers reference</a> provides information about how to make authenticated HTTP requests.
+    The <sky-code>auth</sky-code> configuration option indicates whether the application requires an authenticated Blackbaud ID. This property is for internal Blackbaud use only. <sky-restricted-view>By default, this property is set to <sky-code>false</sky-code>. To require authentication, set this property to <sky-code>true</sky-code>. For Blackbaud developers, <a routerLink="/learn/reference/helpers">the helpers reference</a> provides information about how to make authenticated HTTP requests.</sky-restricted-view>
   </p>
 
   <stache-page-anchor>
@@ -150,11 +150,11 @@
     The <sky-code>cssPath</sky-code> configuration option specifies a path to reference CSS styles. This property is specific to the SKY UX docs site and is for internal Blackbaud use only. To bundle CSS or SCSS files with your SPA, use the <sky-code>styles</sky-code> property of <a stacheRouterLink="." fragment="app">the <sky-code>app</sky-code> configuration option</a> instead.
   </p>
 
-  <stache-page-anchor *skyRestrictedView>
+  <stache-page-anchor>
     <sky-code>help</sky-code>
   </stache-page-anchor>
   <p>
-    The <sky-code>help</sky-code> configuration option indicates whether to automatically include the Help Widget in the application to identify the current page and display relevant help content. This property is for internal Blackbaud use only. By default, this property is set to <sky-code>false</sky-code>. For Blackbaud developers who want to include the Help Widget, <a href="https://docs.blackbaud.com/bb-help-docs/learn/configuration/recommended">the Help Widget configuration options documentation</a> describes the configuration object to set the <sky-code>help</sky-code> property to.
+    The <sky-code>help</sky-code> configuration option indicates whether to automatically include the Help Widget in the application to identify the current page and display relevant help content. This property is for internal Blackbaud use only. <sky-restricted-view>By default, this property is set to <sky-code>false</sky-code>. For Blackbaud developers who want to include the Help Widget, <a href="https://docs.blackbaud.com/bb-help-docs/learn/configuration/recommended">the Help Widget configuration options documentation</a> describes the configuration object to set the <sky-code>help</sky-code> property to.</sky-restricted-view>
   </p>
 
   <stache-page-anchor>
@@ -199,11 +199,11 @@
     The <sky-code>name</sky-code> configuration option specifies the name of the project when running in SKY UX Host. For example, if you specify "demo" as the name, then your SPA is accessible from https://host.nxt.blackbaud.com/demo. By default, SKY UX Builder uses the <sky-code>name</sky-code> property in the <sky-code>package.json</sky-code> file, minus the "blackbaud-skyux-spa-" prefix. That value is based on the root directory name that you specify when you <a routerLink="/learn/get-started/basic/create-project">create a SKY UX project</a>. You can use the <sky-code>name</sky-code> property in <sky-code>skyuxconfig.json</sky-code> to overwrite the default name if you do not want the root directory name in your public-facing URL. For example, if you publish the SPA to NPM, you use the <sky-code>name</sky-code> property in <sky-code>package.json</sky-code>, so you may want to use a different name for the project in SKY UX Host.
   </p>
 
-  <stache-page-anchor *skyRestrictedView>
+  <stache-page-anchor>
     <sky-code>omnibar</sky-code>
   </stache-page-anchor>
   <p>
-    The <sky-code>omnibar</sky-code> configuration option specifies an object to pass to the omnibar's <sky-code>load</sky-code> method. This property is for internal Blackbaud use only. The omnibar provides a common UI element for Blackbaud applications that allows users to navigate between applications. For Blackbaud developers, <a href="https://docs.blackbaud.com/omnibar-docs/learn/configuring">the omnibar configuration options documentation</a> describes the available options to pass to the omnibar.
+    The <sky-code>omnibar</sky-code> configuration option specifies an object to pass to the omnibar's <sky-code>load</sky-code> method. This property is for internal Blackbaud use only. <sky-restricted-view>The omnibar provides a common UI element for Blackbaud applications that allows users to navigate between applications. For Blackbaud developers, <a href="https://docs.blackbaud.com/omnibar-docs/learn/configuring">the omnibar configuration options documentation</a> describes the available options to pass to the omnibar.</sky-restricted-view>
   </p>
 
   <stache-page-anchor>
@@ -376,11 +376,11 @@
   }
   </sky-code-block>
 
-  <stache-page-anchor *skyRestrictedView>
+  <stache-page-anchor>
     <sky-code>routes</sky-code>
   </stache-page-anchor>
   <p>
-    The <sky-code>routes</sky-code> configuration option allows you to use the omnibar but still define navigation items. This property is for internal Blackbaud use only. For Blackbaud developers, the Engineering System website describes how to <a href="https://host.nxt.blackbaud.com/engineering-system-docs/learn/spa/spa-global-navigation">add your SPA to global navigation</a>.
+    The <sky-code>routes</sky-code> configuration option allows you to use the omnibar but still define navigation items. This property is for internal Blackbaud use only. <sky-restricted-view>For Blackbaud developers, the Engineering System website describes how to <a href="https://host.nxt.blackbaud.com/engineering-system-docs/learn/spa/spa-global-navigation">add your SPA to global navigation</a>.</sky-restricted-view>
   </p>
 
   <stache-page-anchor>


### PR DESCRIPTION
This PR includes some of the updates we discussed on the phone, plus a couple style things (one where I rearranged text because a code snippet was smashed up against regular text even though there was a space in the code and one where I changed a p tag back to an alert after reconsidering a recent change). We still need to resolve some of the other issues about how to make the restricted view stuff work, but talking to Tim late Friday afternoon, I think it's doable to update the restricted view library so that there is an option to display one thing for logged in users and a totally different thing for non-logged in users. If so, that would go a long way to addressing the issues we are running into. ... Anyway, hopefully that gives you enough to go on when discussing this with Todd and the rest of the team when I'm out. Thanks.