### PR TITLE
Updated .travis.yml to use new Chrome addon technique.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,6 @@ dist: trusty
 git:
   depth: 10
 
-services:
-  - xvfb
-
-addons:
-  chrome: stable
-
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ dist: trusty
 git:
   depth: 10
 
+services:
+  - xvfb
+
+addons:
+  chrome: stable
+
 branches:
   only:
     - master
@@ -14,16 +20,7 @@ cache:
   directories:
     - node_modules
 
-# http://blog.500tech.com/setting-up-travis-ci-to-run-tests-on-latest-google-chrome-version/
 before_install:
-  - export CHROME_BIN=/usr/bin/google-chrome
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - sudo apt-get update
-  - sudo apt-get install -y libappindicator1 fonts-liberation
-  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-  - sudo dpkg -i google-chrome*.deb
-  - rm google-chrome*.deb
   - npm install -g @skyux-sdk/cli
 
 # Identical to package.json except for travis wait


### PR DESCRIPTION
The build has started failing, as seen with https://github.com/blackbaud/skyux2-docs/pull/641.

The code comment in `.travis.yml` suggests looking at http://blog.500tech.com/setting-up-travis-ci-to-run-tests-on-latest-google-chrome-version/, but that link no longer works.

https://docs.travis-ci.com/user/chrome seems to suggest a simpler approach, likely not available when this repo was first created.  This PR is using the documented approach.