### PR TITLE
Hide StackBlitz buttons that do not work and add missing dependencies

### DIFF
--- a/src/app/components/demo-components.service.ts
+++ b/src/app/components/demo-components.service.ts
@@ -200,7 +200,8 @@ export class SkyDemoComponentsService {
         icon: 'calendar',
         summary: `The date range picker component creates a text input for users to select a date range from a set of well-known options.`,
         url: '/components/date-range-picker',
-        getCodeFiles: () => this.getDemoFiles('Date range picker')
+        getCodeFiles: () => this.getDemoFiles('Date range picker'),
+        disableStackblitz: true
       },
       {
         name: 'Definition list',
@@ -281,6 +282,9 @@ export class SkyDemoComponentsService {
             'SkyFilterModule',
             'SkyRepeaterModule'
           ],
+          '@skyux/list-builder': [
+            'SkyListModule'
+          ],
           '@skyux/inline-form': [
             'SkyInlineFormModule'
           ],
@@ -293,6 +297,11 @@ export class SkyDemoComponentsService {
           '@skyux/forms': [
             'SkyCheckboxModule'
           ]
+        },
+        dependencies: {
+          'microedge-rxstate': '*',
+          '@skyux/list-builder-common': '*',
+          '@skyux/lookup': '*'
         },
         getCodeFiles: () => [
           ...this.getDemoFiles('Filter'),
@@ -447,7 +456,8 @@ export class SkyDemoComponentsService {
         icon: 'keyboard-o',
         summary: 'The inline form component renders a form in the current view rather than in a modal.',
         url: '/components/inline-form',
-        getCodeFiles: () => this.getDemoFiles('Inline form')
+        getCodeFiles: () => this.getDemoFiles('Inline form'),
+        disableStackblitz: true
       },
       {
         name: 'Key info',
@@ -771,12 +781,18 @@ export class SkyDemoComponentsService {
           '@skyux/lists': [
             'SkyPagingModule'
           ],
+          '@skyux/list-builder': [
+            'SkyListModule'
+          ],
           '@skyux/inline-form': [
             'SkyInlineFormModule'
           ]
         },
         dependencies: {
-          '@skyux/lists': '3.2.2'
+          'microedge-rxstate': '*',
+          '@skyux/lists': '3.2.2',
+          '@skyux/list-builder-common': '*',
+          '@skyux/lookup': '*'
         },
         getCodeFiles: () => this.getDemoFiles('Paging')
       },
@@ -787,6 +803,9 @@ export class SkyDemoComponentsService {
         summary: `The phone field module creates a button, search input, and text input for entering and validating phone numbers.`,
         url: '/components/phone-field',
         imports: {
+          '@skyux/lookup': [
+            'SkyLookupModule'
+          ],
           '@skyux/phone-field': [
             'SkyPhoneFielddModule'
           ]
@@ -794,7 +813,8 @@ export class SkyDemoComponentsService {
         dependencies: {
           '@skyux/phone-field': '*'
         },
-        getCodeFiles: () => this.getDemoFiles('Phone field')
+        getCodeFiles: () => this.getDemoFiles('Phone field'),
+        disableStackblitz: true
       },
       {
         name: 'Popover',
@@ -868,6 +888,9 @@ export class SkyDemoComponentsService {
         summary: `The search component creates a mobile-responsive input control for users to enter search criteria.`,
         url: '/components/search',
         imports: {
+          '@skyux/list-builder': [
+            'SkyListModule'
+          ],
           '@skyux/lookup': [
             'SkySearchModule'
           ],
@@ -880,6 +903,10 @@ export class SkyDemoComponentsService {
           '@skyux/inline-form': [
             'SkyInlineFormModule'
           ]
+        },
+        dependencies: {
+          'microedge-rxstate': '*',
+          '@skyux/list-builder-common': '*'
         },
         getCodeFiles: () => this.getDemoFiles('Search')
       },
@@ -900,7 +927,8 @@ export class SkyDemoComponentsService {
             'SkyCheckboxModule'
           ]
         },
-        getCodeFiles: () => this.getDemoFiles('Sectioned form')
+        getCodeFiles: () => this.getDemoFiles('Sectioned form'),
+        disableStackblitz: true
       },
       {
         name: 'Select field',
@@ -964,7 +992,8 @@ export class SkyDemoComponentsService {
         icon: 'columns',
         summary: `The split view component displays a list alongside a workspace where users can view details and take actions.`,
         url: '/components/split-view',
-        getCodeFiles: () => this.getDemoFiles('Split view')
+        getCodeFiles: () => this.getDemoFiles('Split view'),
+        disableStackblitz: true
       },
       {
         name: 'Status indicator',
@@ -1136,7 +1165,8 @@ export class SkyDemoComponentsService {
             'SkyVerticalTabsetModule'
           ]
         },
-        getCodeFiles: () => this.getDemoFiles('Vertical tabs')
+        getCodeFiles: () => this.getDemoFiles('Vertical tabs'),
+        disableStackblitz: true
       },
       {
         name: 'Wait',


### PR DESCRIPTION
Addresses https://github.com/blackbaud/skyux2-docs/issues/643, and also updates missing dependencies for buttons that work but load the demos without the necessary dependencies.