### PR TITLE
Used text instead of an image to call out the correct SDK + getting started guide

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1329,9 +1329,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.11.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.5.tgz",
-      "integrity": "sha512-LC8ALj/24PhByn39nr5jnTvpE7MujK8y7LQmV74kHYF5iQ0odCPkMH4IZNZw+cobKfSXqaC8GgegcbIsQpffdA==",
+      "version": "12.11.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.6.tgz",
+      "integrity": "sha512-4uPUyY1Aofo1YzoypalYHNd2SnKYxH2b6LzXwpryZCJKA2XlagZSynXx5C8sfPH0r1cSltUpaVHV2q5sYXschQ==",
       "dev": true
     },
     "@types/q": {
@@ -6049,9 +6049,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
     },
     "graceful-readlink": {

--- a/src/app/shared/home-component/home.component.html
+++ b/src/app/shared/home-component/home.component.html
@@ -143,7 +143,7 @@ showFooter="false">
               </sky-code-block>
             </div>
             <p class="sky-deemphasized">
-              Check out the <a routerLink="/learn/get-started">getting started guide</a> for a full list of prerequisites.
+              For a full list of prerequisites, see the <a routerLink="/learn/get-started">getting started guide</a>.
             </p>
           </div>
         </sky-column>

--- a/src/app/shared/home-component/home.component.html
+++ b/src/app/shared/home-component/home.component.html
@@ -129,9 +129,23 @@ showFooter="false">
           &nbsp;
         </sky-column>
         <sky-column screenSmall="4">
-          <a routerLink="/learn/reference" class="screenshot screenshot-info">
-            <img src="~/assets/home/feature-sdk-cli.png" alt="Example SDK" />
-          </a>
+          <div> <!-- single child needed -->
+            <div class="screenshot screenshot-info">
+              <sky-code-block 
+                hideCopyToClipboard="true"
+                hideHeader="true"
+                languageType="bash"
+              >
+                npm i -g @skyux-sdk/cli
+                skyux new --name hello-world
+                cd skyux-spa-hello-world
+                skyux serve -l none
+              </sky-code-block>
+            </div>
+            <p class="sky-deemphasized">
+              Check out the <a routerLink="/learn/get-started">getting started guide</a> for a full list of prerequisites.
+            </p>
+          </div>
         </sky-column>
       </sky-row>
       <sky-row>

--- a/src/app/shared/home-component/home.component.scss
+++ b/src/app/shared/home-component/home.component.scss
@@ -42,6 +42,11 @@ $app-info-padding: 45px;
   border-top: solid 1px rgba(226, 227, 228, .8);
 }
 
+.row-features ::ng-deep pre {
+  border: 0;
+  margin-bottom: 0;
+}
+
 .row-features ::ng-deep .sky-row,
 .row-developer ::ng-deep .sky-row {
   padding-bottom: $app-info-padding;


### PR DESCRIPTION
We could update the image from https://carbon.now.sh/ApwqHQj44GE1WHw6tdoU, but I liked @michael-tims suggestion of using code.  We tried this in the past and it visually just wasn't as appealing.  I'm OK with the visual look now.

Fixes https://github.com/blackbaud/skyux2-docs/issues/718