### PR TITLE
Fix list grid sticky settings link

### DIFF
--- a/src/app/components/list/grid/index.html
+++ b/src/app/components/list/grid/index.html
@@ -81,7 +81,7 @@
       propertyName="settingsKey"
       isOptional="true"
     >
-    Specifies a unique key for the UI Config Service to retrieve stored settings from a database. The UI Config Service saves configuration settings for users and returns <sky-code>selectedColumnIds</sky-code> to preserve their preferred column order and the sorting of columns. This property accepts <sky-code>string</sky-code> values. This property is for internal Blackbaud use only. For Blackbaud developers, the UI Config Service website describes how to <a href="https://docs.blackbaud.com/ui-config-service-docs/learn/integrations/skyux-components/grids">apply sticky settings to grids</a>.
+    Specifies a unique key for the UI Config Service to retrieve stored settings from a database. The UI Config Service saves configuration settings for users and returns <sky-code>selectedColumnIds</sky-code> to preserve their preferred column order and the sorting of columns. This property accepts <sky-code>string</sky-code> values. This property is for internal Blackbaud use only. For Blackbaud developers, the UI Config Service website describes how to <a routerLink="../../../learn/get-started/advanced/sticky-settings/integrations/skyux-components/grids">apply sticky settings to grids</a>.
     </sky-demo-page-property>
     <sky-demo-page-property
       propertyName="width"


### PR DESCRIPTION
Link seemed to 404 previously, I think this is where it was pointing now that all the integrations are on the skyux site.