### PR TITLE
remove design resources temporarily

### DIFF
--- a/skyuxconfig.json
+++ b/skyuxconfig.json
@@ -126,6 +126,7 @@
     "contribute/guidelines": "contribute/contribution-process",
     "components/fileattachments": "components/file-attachments",
     "learn/get-started/prereqs/ssl-certificate": "learn/get-started/prereqs",
-    "learn/get-started/prereqs/initial-setup": "learn/get-started/prereqs"
+    "learn/get-started/prereqs/initial-setup": "learn/get-started/prereqs",
+    "design/resources": "design"
   }
 }

--- a/src/app/design/ux-action-button.component.ts
+++ b/src/app/design/ux-action-button.component.ts
@@ -26,13 +26,6 @@ export class DesignActionButtonsComponent {
       icon: 'paint-brush',
       // tslint:disable-next-line
       summary: 'Core design elements that provide the building blocks for SKY UX components.'
-    },
-    {
-      name: 'Resources',
-      path: '/design/resources',
-      icon: 'file-o',
-      // tslint:disable-next-line
-      summary: 'Design resources to help make prototyping more efficient and accurate.'
     }
   ];
 }


### PR DESCRIPTION
There is a bug with the way Sketch and Axure interact with Blackbaud Sans. Removing the design resources page until the libraries are fixed.