### PR TITLE
Update skyAppConfig property chain to get value

### DIFF
--- a/src/app/learn/reference/configuration/additional-config-files/index.html
+++ b/src/app/learn/reference/configuration/additional-config-files/index.html
@@ -120,7 +120,7 @@ import { SkyAppConfig } from '@skyux/config';
 export class HomeComponent {
   public envId: string;
   constructor(skyAppConfig: SkyAppConfig) {
-    this.envId = skyAppConfig.params.get('envid');
+    this.envId = skyAppConfig.runtime.params.get('envid');
   }
 }
   </sky-code-block>


### PR DESCRIPTION
When I went to get a value from the skyAppConfig object the code example given was not correct. There was no params property directly beneath the skyAppConfig object. Instead I called the runtime property and then the params property (I assume that this was correct)