### PR TITLE
Update icon docs

### DIFF
--- a/src/app/components/icon/index.html
+++ b/src/app/components/icon/index.html
@@ -12,7 +12,7 @@
     <sky-demo-page-property
       propertyName="icon"
     >
-      Specifies the name of the Font Awesome icon to display. This property accepts <sky-code>string</sky-code> values.
+      Specifies the name of <a stacheRouterLink="/design/styles/icons">the Font Awesome icon</a> to display. Do not specify the <sky-code>fa fa-</sky-code> classes. This property accepts <sky-code>string</sky-code> values.
     </sky-demo-page-property>
     <sky-demo-page-property
       propertyName="fixedWidth"

--- a/src/app/design/styles/icons/index.html
+++ b/src/app/design/styles/icons/index.html
@@ -46,6 +46,9 @@
   <p>
     The icon dictionary provides a complete list of icons that we recommend for use in SKY UX. All the icons are from <a href="http://fontawesome.io">Font Awesome</a>, and we support version 4.7.0. If Font Awesome does not have a particular icon, it is probably not common enough for its purpose to be immediately obvious to users.
   </p>
+  <p>
+    When you use <a stacheRouterLink="/components/icon">the SKY UX icon component</a> to display Font Awesome icons, do not specify the <sky-code>fa fa-</sky-code> classes.
+  </p>
 
   <div class="icon-wrapper">
     <div class="


### PR DESCRIPTION
Addresses https://github.com/blackbaud/skyux2-docs/issues/727. ... This addresses the point that an external developer raised about the `fa fa-` classes. But it does not include anything about how to color the icon using one of the appropriate styles as @Blackbaud-BenLambert suggested. Do we want to include anything about that? And if so, what guidance do we want to provide?