### PR TITLE
Add toolbar info to page summary docs

### DIFF
--- a/src/app/components/page-summary/index.html
+++ b/src/app/components/page-summary/index.html
@@ -76,4 +76,10 @@
     <sky-demo-page-code demoName="Page summary"></sky-demo-page-code>
   </sky-demo-page-example>
 
+  <sky-demo-page-content sectionHeading="UX guidelines">
+
+    <header><div class="sky-section-heading">Options</div></header>
+      <p>You can use the <a stacheRouterLink="/components/toolbar">toolbar component</a> to display actions in a SKY UX-themed toolbar within the page summary. We recommend that you include only actions that relate to the page as a whole and that you exclude actions that are specific to the tiles on the page. We also recommend that you limit the number of actions in the action bar. If the page summary requires many actions, we recommend that you re-examine the tasks and consider an alternative workflow.</p>
+  
+
 </sky-demo-page>


### PR DESCRIPTION
I looked at adding this info at the end in a UX guidelines section and higher up in a section like the others on the page and opted for the former. We can move as necessary. ... I'll circle back to get rid of multiple instances of empty table headers, but I wanted to go ahead and get the the toolbar updates in place first.