### PR TITLE
Fix casing in radio group property description

### DIFF
--- a/src/app/components/radio/index.html
+++ b/src/app/components/radio/index.html
@@ -284,7 +284,7 @@
 
     <sky-demo-page-properties sectionHeading="Radio button group properties">
       <p>
-        The <sky-code>sky-radio-group</sky-code> component organizes radio buttons into a group. IT is required for radio buttons on Angular reactive forms, and we recommend using it with all radio buttons. On Angular forms, the component manages the selected values and keeps the forms up-to-date. When users select a radio button, its value is driven through an <sky-code>ngModel</sky-code> attribute that you specify on the <sky-code>sky-radio-group</sky-code> element.
+        The <sky-code>sky-radio-group</sky-code> component organizes radio buttons into a group. It is required for radio buttons on Angular reactive forms, and we recommend using it with all radio buttons. On Angular forms, the component manages the selected values and keeps the forms up-to-date. When users select a radio button, its value is driven through an <sky-code>ngModel</sky-code> attribute that you specify on the <sky-code>sky-radio-group</sky-code> element.
       </p>
       <sky-demo-page-property
         propertyName="name"


### PR DESCRIPTION
Just one character out of place that I noticed. Feel free to include with any other changes you have elsewhere and close this PR.