### PR TITLE
Update button label guidance for confirm component

### DIFF
--- a/src/app/components/confirm/index.html
+++ b/src/app/components/confirm/index.html
@@ -146,7 +146,7 @@
         </li>
 			</ul>
 			<p>
-        The answer portion of the dialog answers the question or tells users what will happen. It can contain up to 3 choices represented as terminal actions (buttons) that should reiterate the action to take. For example, use "Delete" for the primary button text if the question is "Are you sure you want to delete this draft?"
+        The answer portion of the dialog answers the question or tells users what will happen. It can contain up to 3 choices represented as terminal actions (buttons) that should reiterate the action to take. The button labels should clearly indicate what action occurs when users select the button. For example, use "Delete" for the primary button text if the question is "Are you sure you want to delete this draft?"
       </p>
 			<ul>
 				<li>


### PR DESCRIPTION
Addresses the guideline portion of https://github.com/blackbaud/skyux-modals/issues/124. (@Blackbaud-AdamFunderburk, this is based on your feedback to a question about confusing confirmation buttons on a Slack thread awhile back, which is why I added you as a reviewer.)