### PR TITLE
Remove breadcrumbs for Component section for consistency

### DIFF
--- a/src/app/components/shared/demo-page.component.html
+++ b/src/app/components/shared/demo-page.component.html
@@ -3,7 +3,9 @@
     layout="sidebar"
     showTableOfContents="true"
     [pageTitle]="pageTitle"
-    [sidebarRoutes]="sidebarRoutes">
+    [sidebarRoutes]="sidebarRoutes"
+    showBreadcrumbs="false"
+>
 
     <stache-page-summary>
 


### PR DESCRIPTION
Addresses https://github.com/blackbaud/skyux2-docs/issues/729.

@Blackbaud-AdamFunderburk and/or @Blackbaud-ToddRoberts, the docs issue indicates that leaving breadcrumbs off of phase 2 docs was a deliberate change to see if it bothered anyone. Given that we never heard any complaints, I'm removing the breadcrumbs for consistency. As we migrate content to the component repos, the breadcrumbs would eventually be removed anyway, but this knocks it all out at once for consistency. ... Also, I confirmed with Steve that to enable breadcrumbs in docs-tools is going to be a dev change, so if we change our minds, it will require a dev issue in the docs-tools reapo.