### PR TITLE
doc: clarify plugin-resources

### DIFF
--- a/src/app/learn/get-started/advanced/localization/index.html
+++ b/src/app/learn/get-started/advanced/localization/index.html
@@ -50,7 +50,7 @@
   <ol>
     <li>
       <p>
-        Create a <sky-code>plugin-resources</sky-code> directory in <sky-code>/src/app/public/plugin-resources</sky-code>. The name and location of the directory are important.
+        Create a <sky-code>/src/app/public/plugin-resources</sky-code> directory. The name and location of the directory are important.
       </p>
     </li>
     <li>


### PR DESCRIPTION
the previous wording implied `/src/app/public/plugin-resources/plugin-resources`, which i'm pretty sure is wrong.