### PR TITLE
Update browser support info

### DIFF
--- a/src/stache/includes/supported-browsers.html
+++ b/src/stache/includes/supported-browsers.html
@@ -1,1 +1,1 @@
-SKY UX supports the latest major version of Edge and Internet Explorer that is available for your version of Windows; the latest version of Firefox and Chrome on both Windows and Mac; the latest verion of Safari on Mac; the latest version of Mobile Safari on IOS; and the latest version of Chrome on Android.
+SKY UX supports Blackbaud's <a href="https://www.blackbaud.com/training-support/support/system-requirements/supported-browsers-system-requirements">system requirements for browser compatibility</a>.


### PR DESCRIPTION
We were asked to update docs on browser support to point to IT's new central resource for supported browser guidance, so I updated our content to just link to the new guidance given that it seemed to be completely in sync (only with more details in the new guidance).